### PR TITLE
use github mirror for openstack client

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ ops >= 1.2.0
 kubernetes
 jinja2
 pyyaml
-git+https://opendev.org/openstack/charm-ops-interface-ceph-client@d4d0cefc5e92edd28cdbf5d00e190d4498896418#egg=interface_ceph_client
+git+https://github.com/openstack/charm-ops-interface-ceph-client@d4d0cefc5e92edd28cdbf5d00e190d4498896418#egg=interface_ceph_client
 
 # require netifaces to prevent a dynamic apt install during interface_ceph_client -> charmhelpers import
 # https://github.com/juju/charm-helpers/blob/a72931f7324526e7f05221847437238517f38fa7/charmhelpers/contrib/network/ip.py#L37-L42


### PR DESCRIPTION
Switch to using the github mirror of the openstack ops interface so CI doesn't have to expose another server through the firewall