### PR TITLE
adds deployment replica set configuration

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,5 +19,7 @@ jobs:
   lint-unit:
     name: Lint Unit
     uses: charmed-kubernetes/workflows/.github/workflows/lint-unit.yaml@main
+    with:
+      python: "['3.8', '3.9', '3.10', '3.11']"
     needs:
       - call-inclusive-naming-check

--- a/.github/workflows/vsphere-integration.yaml
+++ b/.github/workflows/vsphere-integration.yaml
@@ -21,6 +21,7 @@ jobs:
           clouds-yaml: ${{ secrets.CLOUDS_YAML }}
           bootstrap-constraints: "arch=amd64 cores=2 mem=4G"
           bootstrap-options: "${{ secrets.FOCAL_BOOTSTRAP_OPTIONS }} --model-default datastore=vsanDatastore --model-default primary-network=VLAN_2763 --config caas-image-repo=rocks.canonical.com/cdk/jujusolutions"
+          juju-channel: "3.1/stable"
       - name: Run test
         run: tox -e func
       - name: Setup Debug Artifact Collection

--- a/.github/workflows/vsphere-integration.yaml
+++ b/.github/workflows/vsphere-integration.yaml
@@ -37,7 +37,7 @@ jobs:
           mv juju-crashdump-* tmp/ | true
       - name: Upload debug artifacts
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: test-run-artifacts
           path: tmp

--- a/.github/workflows/vsphere-integration.yaml
+++ b/.github/workflows/vsphere-integration.yaml
@@ -8,9 +8,9 @@ jobs:
     timeout-minutes: 120
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Setup operator environment
@@ -20,10 +20,12 @@ jobs:
           credentials-yaml: ${{ secrets.CREDENTIALS_YAML }}
           clouds-yaml: ${{ secrets.CLOUDS_YAML }}
           bootstrap-constraints: "arch=amd64 cores=2 mem=4G"
-          bootstrap-options: "${{ secrets.FOCAL_BOOTSTRAP_OPTIONS }} --model-default datastore=vsanDatastore --model-default primary-network=VLAN_2763 --config caas-image-repo=rocks.canonical.com/cdk/jujusolutions"
+          bootstrap-options: "${{ secrets.JAMMY_BOOTSTRAP_OPTIONS }} --model-default datastore=vsanDatastore --model-default primary-network=VLAN_2763 --config caas-image-repo=rocks.canonical.com/cdk/jujusolutions"
           juju-channel: "3.1/stable"
+
       - name: Run test
-        run: tox -e func
+        run: tox -e func -- --basetemp=/home/ubuntu/pytest
+
       - name: Setup Debug Artifact Collection
         if: ${{ failure() }}
         run: mkdir tmp

--- a/config.yaml
+++ b/config.yaml
@@ -8,3 +8,8 @@ options:
     default: ceph-xfs
     description: "Default storage class to use. Allowed values: 'ceph-ext4', 'ceph-xfs'"
     type: string
+
+  provisioner-replicas:
+    default: 3
+    description: "Number of replicas of any csi-*plugin-provisioner deployment"
+    type: int

--- a/src/charm.py
+++ b/src/charm.py
@@ -200,6 +200,11 @@ log file = /var/log/ceph.log
         return fsid
 
     @property
+    def provisioner_replicas(self) -> int:
+        """Get the number of csi-*plugin-provisioner replicas."""
+        return int(self.config.get("provisioner-replicas") or 3)
+
+    @property
     def ceph_context(self) -> Dict[str, Any]:
         """Return context that can be used to render ceph resource files in templates/ folder."""
         return {
@@ -207,6 +212,7 @@ log file = /var/log/ceph.log
             "kubernetes_key": self.key,
             "mon_hosts": json.dumps(self.mon_hosts),
             "user": self.app.name,
+            "provisioner_replicas": self.provisioner_replicas,
         }
 
     @property
@@ -438,6 +444,25 @@ log file = /var/log/ceph.log
         self.request_ceph_pools()
         self.request_ceph_permissions()
 
+    def _update_resources(self) -> bool:
+        if updated := cast(bool, self._stored.resources_created):
+            # Update already existing resources that depend on ceph-client data
+            secret_key = self.key or ""
+            fsid = self.get_ceph_fsid()
+            mon_hosts = self.mon_hosts
+
+            for resource in self.resources:
+                if isinstance(resource, Secret):
+                    resource.update_opaque_data("userKey", secret_key)
+                elif isinstance(resource, StorageClass):
+                    resource.update_cluster_id(fsid)
+                elif isinstance(resource, ConfigMap):
+                    config_data = [{"clusterID": fsid, "monitors": mon_hosts}]
+                    resource.update_config_json(json.dumps(config_data, indent=4))
+                elif isinstance(resource, Deployment):
+                    resource.update_replicas(self.provisioner_replicas)
+        return updated
+
     def _on_ceph_client_changed(self, event: RelationChangedEvent) -> None:
         """Fetch information from ceph-client relation and update Kubernetes
         resources
@@ -449,21 +474,7 @@ log file = /var/log/ceph.log
 
         if self.safe_load_ceph_client_data():
             self.configure_ceph_cli()
-            if cast(bool, self._stored.resources_created):
-                # Update already existing resources that depend on ceph-client data
-                secret_key = self.key or ""
-                fsid = self.get_ceph_fsid()
-                mon_hosts = self.mon_hosts
-
-                for resource in self.resources:
-                    if isinstance(resource, Secret):
-                        resource.update_opaque_data("userKey", secret_key)
-                    elif isinstance(resource, StorageClass):
-                        resource.update_cluster_id(fsid)
-                    elif isinstance(resource, ConfigMap):
-                        config_data = [{"clusterID": fsid, "monitors": mon_hosts}]
-                        resource.update_config_json(json.dumps(config_data, indent=4))
-            else:
+            if not self._update_resources():
                 # No kubernetes resources exist yet. This is the first time that ceph-client
                 # relation has all the required data
                 all_resources = self.render_all_resource_definitions()
@@ -477,7 +488,6 @@ log file = /var/log/ceph.log
                     logger.info("ControlPlane not yet ready...")
                     event.defer()
                     return
-
                 self._stored.resources_created = True
             self.unit.status = UNIT_READY_STATUS
 
@@ -519,9 +529,12 @@ log file = /var/log/ceph.log
                 )
                 return
 
+        # Update resources if they are currently installed in cluster
+        self._update_resources()
+
         # Resolve blocked state caused by bad configuration
         status = self.unit.status
-        if status.name == BlockedStatus.name and status.message.startswith(BAD_CONFIG_PREFIX):
+        if isinstance(status, BlockedStatus) and status.message.startswith(BAD_CONFIG_PREFIX):
             self.unit.status = UNIT_READY_STATUS
 
 

--- a/src/resource.py
+++ b/src/resource.py
@@ -307,6 +307,14 @@ class Deployment(AppsResource):
     def _remove_namespaced_action(self) -> Callable:
         return self.api.delete_namespaced_deployment
 
+    @property
+    def _update_namespaced_action(self) -> Callable:
+        return self.api.patch_namespaced_deployment
+
+    def update_replicas(self, count: int) -> None:
+        """Update replicas value."""
+        self.update({"spec": {"replicas": count}})
+
 
 class DaemonSet(AppsResource):
     """Kubernetes 'DaemonSet' resource."""

--- a/templates/csi-rbdplugin-provisioner.yaml.j2
+++ b/templates/csi-rbdplugin-provisioner.yaml.j2
@@ -20,7 +20,7 @@ apiVersion: apps/v1
 metadata:
   name: csi-rbdplugin-provisioner
 spec:
-  replicas: 3
+  replicas: {{ provisioner_replicas or 3 }}
   selector:
     matchLabels:
       app: csi-rbdplugin-provisioner

--- a/tests/functional/overlay.yaml
+++ b/tests/functional/overlay.yaml
@@ -12,13 +12,13 @@ applications:
     expose: true
   ceph-mon:
     charm: ceph-mon
-    channel: "pacific/stable"
+    channel: "quincy/stable"
     num_units: 3
     options:
       monitor-count: '3'
   ceph-osd:
     charm: ceph-osd
-    channel: "pacific/stable"
+    channel: "quincy/stable"
     num_units: 3
     constraints: "cores=2 mem=4G"
     options:
@@ -28,6 +28,8 @@ applications:
       osd-journals: 1G,1
   ceph-csi:
     charm: {{ charm }}
+    options:
+      provisioner-replicas: 2
 relations:
 - - ceph-osd
   - ceph-mon

--- a/tests/functional/overlay.yaml
+++ b/tests/functional/overlay.yaml
@@ -12,13 +12,13 @@ applications:
     expose: true
   ceph-mon:
     charm: ceph-mon
-    channel: "quincy/stable"
+    channel: "pacific/stable"
     num_units: 3
     options:
       monitor-count: '3'
   ceph-osd:
     charm: ceph-osd
-    channel: "quincy/stable"
+    channel: "pacific/stable"
     num_units: 3
     constraints: "cores=2 mem=4G"
     options:

--- a/tests/functional/templates/persistent_volume.yaml.j2
+++ b/tests/functional/templates/persistent_volume.yaml.j2
@@ -2,8 +2,6 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: pvc-test-{{ storage_class }}
-  annotations:
-   volume.beta.kubernetes.io/storage-class: {{ storage_class }}
 spec:
   accessModes:
   - ReadWriteOnce

--- a/tests/functional/test_ceph_csi.py
+++ b/tests/functional/test_ceph_csi.py
@@ -71,7 +71,9 @@ async def test_deployment_replicas(kube_config: Path, namespace: str, ops_test):
     (rbdplugin,) = apps_api.list_namespaced_deployment(namespace).items
     k8s_workers = ops_test.model.applications["kubernetes-worker"]
     assert rbdplugin.status.replicas == 2  # from the test overlay.yaml
-    assert rbdplugin.status.ready_replicas == len(k8s_workers.units)
+    # Due to anti-affinity rules on the control-plane, the ready replicas
+    # are limited to the number of worker nodes
+    assert rbdplugin.status.ready_replicas <= len(k8s_workers.units)
 
 
 @pytest.mark.parametrize("storage_class", ["ceph-xfs", "ceph-ext4"])

--- a/tests/functional/test_ceph_csi.py
+++ b/tests/functional/test_ceph_csi.py
@@ -64,6 +64,16 @@ async def test_active_status(ops_test: OpsTest):
         assert unit.workload_status_message == "Unit is ready"
 
 
+async def test_deployment_replicas(kube_config: Path, namespace: str, ops_test):
+    """Test that ceph-csi deployments run the correctly sized replicas."""
+    config.load_kube_config(str(kube_config))
+    apps_api = client.AppsV1Api()
+    (rbdplugin,) = apps_api.list_namespaced_deployment(namespace).items
+    k8s_workers = ops_test.model.applications["kubernetes-worker"]
+    assert rbdplugin.status.replicas == 2  # from the test overlay.yaml
+    assert rbdplugin.status.ready_replicas == len(k8s_workers.units)
+
+
 @pytest.mark.parametrize("storage_class", ["ceph-xfs", "ceph-ext4"])
 async def test_storage_class(
     kube_config: Path, storage_class: str, namespace: str, cleanup_k8s: None, ops_test

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -158,6 +158,7 @@ log file = /var/log/ceph.log
             "kubernetes_key": key,
             "mon_hosts": expected_monitors_format,
             "user": "ceph-csi",
+            "provisioner_replicas": 3,
         }
 
         self.assertEqual(self.harness.charm.ceph_context, expected_context)
@@ -510,6 +511,7 @@ log file = /var/log/ceph.log
         self.patch(ConfigMap, "update_config_json")
         self.patch(Secret, "update_opaque_data")
         self.patch(StorageClass, "update_cluster_id")
+        self.patch(Deployment, "update_replicas")
         self.harness.charm._stored.resources_created = True
         self.harness.set_leader(True)
         relation_id = self.harness.add_relation(CephCsiCharm.CEPH_CLIENT_RELATION, "ceph-mon")
@@ -530,6 +532,7 @@ log file = /var/log/ceph.log
         ConfigMap.update_config_json.assert_called_with(
             json.dumps([{"clusterID": "abcde", "monitors": ["10.0.0.1"]}], indent=4)
         )
+        Deployment.update_replicas.assert_called_once_with(3)
 
     def test_ceph_client_relation_changed_non_leader(self):
         self.harness.set_leader(False)

--- a/tests/unit/test_resource.py
+++ b/tests/unit/test_resource.py
@@ -346,6 +346,17 @@ class TestResourceActions(unittest.TestCase):
 
         self.remove_action_mock.assert_called_once_with(self.res_name, self.res_namespace)
 
+    def test_deployment_update_replicas(self):
+        """Test that `Deployment.update_replicas` calls update method properly."""
+        new_value = "~~patched~~"
+        expected_patch = {"spec": {"replicas": new_value}}
+
+        deployment = Deployment(self.api_mock, self.res_name, self.res_namespace)
+        update_mock = self.patch(deployment.api, "patch_namespaced_deployment")
+        deployment.update_replicas(new_value)
+
+        update_mock.assert_called_once_with(self.res_name, self.res_namespace, body=expected_patch)
+
     def test_daemon_set_removal(self):
         """Test that removing DaemonSet resource calls appropriate api method."""
         self.api_mock.delete_namespaced_daemon_set = self.remove_action_mock

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ commands =
            {posargs} \
            {toxinidir}/tests/functional/
 
-[testenv:format-code]
+[testenv:format]
 envdir = {toxworkdir}/lint
 basepython = python3
 commands =


### PR DESCRIPTION
The [csi-rbdplugin-provisioner](https://github.com/ceph/ceph-csi/blob/devel/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml#L27) defaults to 3 ReplicaSet, but in cases where there are only two workers the pod will constantly be in a "Pending" state due to Anti-Affinity rules, it was not possible to change the manifest because the charm only loaded the manifest csi-rbdplugin-provisioner.yaml which already has the hardcoded replicaset option.

LP: https://bugs.launchpad.net/cdk-addons/+bug/2004388