### PR TITLE
[LP#2007423] Address ceph-rbd-provisioner being able to use `hostNetworking`

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -13,3 +13,8 @@ options:
     default: 3
     description: "Number of replicas of any csi-*plugin-provisioner deployment"
     type: int
+
+  enable-host-networking:
+    default: false
+    description: "Whether or not csi-*plugin-provisioner deployments use host-networking"
+    type: boolean

--- a/src/charm.py
+++ b/src/charm.py
@@ -207,6 +207,11 @@ log file = /var/log/ceph.log
         return int(self.config.get("provisioner-replicas") or 3)
 
     @property
+    def enable_host_network(self) -> bool:
+        """Get the hostNetwork enabling of csi-*plugin-provisioner deployments."""
+        return bool(self.config.get("enable-host-networking"))
+
+    @property
     def ceph_context(self) -> Dict[str, Any]:
         """Return context that can be used to render ceph resource files in templates/ folder."""
         return {
@@ -216,6 +221,7 @@ log file = /var/log/ceph.log
             "mon_hosts": json.dumps(self.mon_hosts),
             "user": self.app.name,
             "provisioner_replicas": self.provisioner_replicas,
+            "enable_host_network": json.dumps(self.enable_host_network),
         }
 
     @property
@@ -472,6 +478,7 @@ log file = /var/log/ceph.log
                     resource.update_config_json(json.dumps(config_data, indent=4))
                 elif isinstance(resource, Deployment):
                     resource.update_replicas(self.provisioner_replicas)
+                    resource.update_host_networking(self.enable_host_network)
         return updated
 
     def _on_ceph_client_changed(self, event: RelationChangedEvent) -> None:

--- a/src/resource.py
+++ b/src/resource.py
@@ -325,6 +325,10 @@ class Deployment(AppsResource):
         """Update replicas value."""
         self.update({"spec": {"replicas": count}})
 
+    def update_host_networking(self, enabled: bool) -> None:
+        """Update hostNetwork value."""
+        self.update({"spec": {"template": {"spec": {"hostNetwork": enabled}}}})
+
 
 class DaemonSet(AppsResource):
     """Kubernetes 'DaemonSet' resource."""

--- a/templates/csi-rbdplugin-provisioner.yaml.j2
+++ b/templates/csi-rbdplugin-provisioner.yaml.j2
@@ -43,6 +43,7 @@ spec:
                       - csi-rbdplugin-provisioner
               topologyKey: "kubernetes.io/hostname"
       serviceAccountName: rbd-csi-provisioner
+      hostNetwork: {{ enable_host_network }}
       priorityClassName: system-cluster-critical
       containers:
         - name: csi-provisioner

--- a/tests/functional/overlay.yaml
+++ b/tests/functional/overlay.yaml
@@ -30,6 +30,7 @@ applications:
     charm: {{ charm }}
     options:
       provisioner-replicas: 2
+      enable-host-networking: true
 relations:
 - - ceph-osd
   - ceph-mon

--- a/tests/functional/overlay.yaml
+++ b/tests/functional/overlay.yaml
@@ -10,6 +10,7 @@ applications:
       allow-privileged: "true"
   kubernetes-worker:
     expose: true
+    num_units: 2
   ceph-mon:
     charm: ceph-mon
     channel: "pacific/stable"
@@ -30,7 +31,7 @@ applications:
     charm: {{ charm }}
     options:
       provisioner-replicas: 2
-      enable-host-networking: true
+      enable-host-networking: false
 relations:
 - - ceph-osd
   - ceph-mon

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -160,6 +160,7 @@ log file = /var/log/ceph.log
             "mon_hosts": expected_monitors_format,
             "user": "ceph-csi",
             "provisioner_replicas": 3,
+            "enable_host_network": "false",
         }
 
         self.assertEqual(self.harness.charm.ceph_context, expected_context)
@@ -515,6 +516,7 @@ log file = /var/log/ceph.log
         self.patch(Secret, "update_opaque_data")
         self.patch(StorageClass, "update_cluster_id")
         self.patch(Deployment, "update_replicas")
+        self.patch(Deployment, "update_host_networking")
         self.harness.charm._stored.resources_created = True
         self.harness.set_leader(True)
         relation_id = self.harness.add_relation(CephCsiCharm.CEPH_CLIENT_RELATION, "ceph-mon")

--- a/tests/unit/test_resource.py
+++ b/tests/unit/test_resource.py
@@ -374,6 +374,17 @@ class TestResourceActions(unittest.TestCase):
 
         update_mock.assert_called_once_with(self.res_name, self.res_namespace, body=expected_patch)
 
+    def test_deployment_update_host_network(self):
+        """Test that `Deployment.update_host_network` calls update method properly."""
+        new_value = "~~False~~"
+        expected_patch = {"spec": {"template": {"spec": {"hostNetwork": new_value}}}}
+
+        deployment = Deployment(self.api_mock, self.res_name, self.res_namespace)
+        update_mock = self.patch(deployment.api, "patch_namespaced_deployment")
+        deployment.update_host_networking(new_value)
+
+        update_mock.assert_called_once_with(self.res_name, self.res_namespace, body=expected_patch)
+
     def test_daemon_set_removal(self):
         """Test that removing DaemonSet resource calls appropriate api method."""
         self.api_mock.delete_namespaced_daemon_set = self.remove_action_mock


### PR DESCRIPTION
LP#2007423 [make hostnetworking configurable](https://bugs.launchpad.net/charm-ceph-csi/+bug/2007423)

Adds a configuration option to the charm to make host networking configurable similarly to upstream
* [upstream reference](https://github.com/ceph/ceph-csi/blob/b7b491c0977336680a6ad6d7587881d7dc4ffccc/charts/ceph-csi-rbd/templates/provisioner-deployment.yaml#L53)