### PR TITLE
LP#2034267 Support custom directory for kubelet

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -16,5 +16,8 @@ requires:
   kubernetes:
     interface: juju-info
     scope: container
+  kubernetes-info:
+    interface: kubernetes-info
+    scope: container
 
 subordinate: true

--- a/src/manifests_cephfs.py
+++ b/src/manifests_cephfs.py
@@ -129,6 +129,17 @@ class ProvisionerAdjustments(Patch):
             obj.spec.template.spec.tolerations = [Toleration(operator="Exists")]
             log.info("Updating daemonset tolerations to operator=Exists")
 
+            kubelet_dir = self.manifests.config.get("kubelet_dir", "/var/lib/kubelet")
+
+            for c in obj.spec.template.spec.containers:
+                c.args = [arg.replace("/var/lib/kubelet", kubelet_dir) for arg in c.args]
+                for m in c.volumeMounts:
+                    m.mountPath = m.mountPath.replace("/var/lib/kubelet", kubelet_dir)
+            for v in obj.spec.template.spec.volumes:
+                if v.hostPath:
+                    v.hostPath.path = v.hostPath.path.replace("/var/lib/kubelet", kubelet_dir)
+            log.info(f"Updating CephFS daemonset kubeletDir to {kubelet_dir}")
+
 
 class RbacAdjustments(Patch):
     """Update RBD RBAC Attributes."""
@@ -177,6 +188,7 @@ class CephFSManifests(SafeManifest):
         config["image-registry"] = "rocks.canonical.com:443/cdk"
 
         config.update(**self.charm.ceph_context)
+        config.update(**self.charm.kubernetes_context)
         config.update(**self.charm.config)
 
         for key, value in dict(**config).items():


### PR DESCRIPTION
### Summary

Add a config option that makes it possible to adjust the root kubelet dir on the Ceph CSI manifests that are applied on the cluster.

This is to support using the ceph-csi-operator with MicroK8s.

### Notes regarding manifest changes

The following items are changed on the RBD and CephFS plugin manifests:

1. All host paths that include `/var/lib/kubelet` are replaced with `kubeletDir`
2. All volume mounts that include `/var/lib/kubelet` are replaced with `kubeletDir`
3. All command-line arguments that include `/var/lib/kubelet` are replaced with `kubeletDir`

Change (1) is expectedly necessary, whereas (2) and (3) may seem to be not required. This is in fact not true due to internal CSI driver workings, leading to errors when attempting to mount PVCs to pods.

### Notes regarding MicroK8s support

Further changes are required in the MicroK8s charm to make sure that it works with the ceph-csi charm.