### PR TITLE
LP:2054486 make fsname a prereq for enabling cephfs support

### DIFF
--- a/src/manifests_cephfs.py
+++ b/src/manifests_cephfs.py
@@ -55,7 +55,7 @@ class CephStorageClass(Addition):
     """Create ceph storage classes."""
 
     STORAGE_NAME = "cephfs"
-    REQUIRED_CONFIG = {"fsid"}
+    REQUIRED_CONFIG = {"fsid", "fsname"}
     PROVISIONER = "cephfs.csi.ceph.com"
     POOL = "ceph-fs_data"
 
@@ -72,8 +72,8 @@ class CephStorageClass(Addition):
 
         fsname = self.manifests.config.get("fsname")
         if not fsname:
-            fsname = "default"
-            log.info("CephFS Storage Class using default fsName: 'default'")
+            log.error("CephFS is missing required storage item: 'fsname'")
+            return None
 
         ns = self.manifests.config["namespace"]
         metadata: Dict[str, Any] = dict(name=self.STORAGE_NAME)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -525,3 +525,26 @@ def test_check_namespace(harness, lk_charm_client):
     # should be true if no api errors
     lk_charm_client.get.side_effect = None
     assert harness.charm._check_namespace(mock_event, "ns")
+
+
+def test_check_cephfs(harness):
+    mock_event = mock.MagicMock()
+    harness.begin_with_initial_hooks()
+
+    # no enable, no fsname -> no problem
+    harness.update_config({"cephfs-enable": False})
+    with mock.patch("charm.CephCsiCharm.ceph_context", new_callable=mock.PropertyMock) as mock_ctx:
+        mock_ctx.return_value = {"fsname": None}
+        assert harness.charm._check_cephfs(mock_event)
+
+    # enable, fsname -> no problem
+    harness.update_config({"cephfs-enable": True})
+    with mock.patch("charm.CephCsiCharm.ceph_context", new_callable=mock.PropertyMock) as mock_ctx:
+        mock_ctx.return_value = {"fsname": "abcd"}
+        assert harness.charm._check_cephfs(mock_event)
+
+    # enable, no fsname -> problem
+    harness.update_config({"cephfs-enable": True})
+    with mock.patch("charm.CephCsiCharm.ceph_context", new_callable=mock.PropertyMock) as mock_ctx:
+        mock_ctx.return_value = {"fsname": None}
+        assert not harness.charm._check_cephfs(mock_event)

--- a/tests/unit/test_manifests_cephfs.py
+++ b/tests/unit/test_manifests_cephfs.py
@@ -60,6 +60,7 @@ def test_ceph_storage_class_modeled(caplog):
     manifest.config = {
         "enabled": True,
         "fsid": "abcd",
+        "fsname": "abcd",
         "namespace": alt_ns,
         "default-storage": CephStorageClass.STORAGE_NAME,
         "cephfs-mounter": "fuse",
@@ -79,7 +80,7 @@ def test_ceph_storage_class_modeled(caplog):
             "csi.storage.k8s.io/provisioner-secret-namespace": alt_ns,
             "csi.storage.k8s.io/node-stage-secret-name": StorageSecret.SECRET_NAME,
             "csi.storage.k8s.io/node-stage-secret-namespace": alt_ns,
-            "fsName": "default",
+            "fsName": "abcd",
             "mounter": "fuse",
             "pool": "ceph-fs_data",
         },
@@ -87,7 +88,6 @@ def test_ceph_storage_class_modeled(caplog):
         reclaimPolicy="Delete",
     )
     assert csc() == expected
-    assert "CephFS Storage Class using default fsName" in caplog.text
     assert f"Modelling storage class {CephStorageClass.STORAGE_NAME}" in caplog.text
 
 
@@ -103,8 +103,15 @@ def test_manifest_evaluation(caplog):
 
     charm.config = {
         "cephfs-enable": True,
+        "fsid": "cluster",
+    }
+    assert manifests.evaluate() == "CephFS manifests require the definition of 'fsname'"
+
+    charm.config = {
+        "cephfs-enable": True,
         "user": "cephx",
         "fsid": "cluster",
+        "fsname": "abcd",
         "kubernetes_key": "123",
     }
     assert manifests.evaluate() is None


### PR DESCRIPTION
[LP:2054486](https://bugs.launchpad.net/charm-ceph-csi/+bug/2054486)

CephFS may not be available when ceph-csi is deployed. If our `cephfs-enable=True` config is set during this time, `fsname` is set to `None` and the cephfs storage class will be configured incorrectly.

Since `ceph-fs` is managed/configured independently of `ceph-csi`, we need to ensure we only setup the storage class *after* a `ceph-fs` filesystem is available. Do this by ensuring we can get the `fsname` before applying any manifests when `cephfs-enable=True`.