### PR TITLE
Use the update-status hook for retries

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,10 @@ ops >= 1.2.0
 ops.manifest >= 1.1.3, < 2.0
 jinja2
 pyyaml
-git+https://github.com/openstack/charm-ops-interface-ceph-client@d4d0cefc5e92edd28cdbf5d00e190d4498896418#egg=interface_ceph_client
+
+interface_ceph_client @ git+https://github.com/openstack/charm-ops-interface-ceph-client@d4d0cefc5e92edd28cdbf5d00e190d4498896418
+charmhelpers == 1.2.1
+setuptools == 69.5.1
 
 # require netifaces to prevent a dynamic apt install during interface_ceph_client -> charmhelpers import
 # https://github.com/juju/charm-helpers/blob/a72931f7324526e7f05221847437238517f38fa7/charmhelpers/contrib/network/ip.py#L37-L42

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -528,23 +528,22 @@ def test_check_namespace(harness, lk_charm_client):
 
 
 def test_check_cephfs(harness):
-    mock_event = mock.MagicMock()
     harness.begin_with_initial_hooks()
 
     # no enable, no fsname -> no problem
     harness.update_config({"cephfs-enable": False})
     with mock.patch("charm.CephCsiCharm.ceph_context", new_callable=mock.PropertyMock) as mock_ctx:
         mock_ctx.return_value = {"fsname": None}
-        assert harness.charm._check_cephfs(mock_event)
+        assert harness.charm._check_cephfs()
 
     # enable, fsname -> no problem
     harness.update_config({"cephfs-enable": True})
     with mock.patch("charm.CephCsiCharm.ceph_context", new_callable=mock.PropertyMock) as mock_ctx:
         mock_ctx.return_value = {"fsname": "abcd"}
-        assert harness.charm._check_cephfs(mock_event)
+        assert harness.charm._check_cephfs()
 
     # enable, no fsname -> problem
     harness.update_config({"cephfs-enable": True})
     with mock.patch("charm.CephCsiCharm.ceph_context", new_callable=mock.PropertyMock) as mock_ctx:
         mock_ctx.return_value = {"fsname": None}
-        assert not harness.charm._check_cephfs(mock_event)
+        assert not harness.charm._check_cephfs()

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ deps = -r{toxinidir}/requirements-dev.txt
 basepython = python3
 commands =
     codespell {[vars]all_path}
-    ruff {[vars]all_path}
+    ruff check {[vars]all_path}
     isort --check-only --diff {[vars]all_path}
     black -l 99 --check --diff {[vars]all_path}
     mypy --namespace-packages {[vars]src_path}


### PR DESCRIPTION
### Overview
When `ceph-mon`, `ceph-osd`, `cephfs` and `ceph-csi` all deploy at the same time, there can be a race conditions where `ceph-mon` has completed its relation with `ceph-csi`, all the config has been applied, but `cephfs` and `ceph-mon` aren't complete.  

This leads to situations where there is no cephfs_name, and the cephfs deployment cannot complete. 

### Details
* Use the `update-status` hook as a last chance effort to unblocked the `ceph-csi` charm if the cephfs name is finally available. 
* nail down more of the requirements used to build the charm for reproducability
* add more complete logging when the ceph cli commands fail