### PR TITLE
Reimagine ceph-csi charm with the reconciler pattern

### DIFF
--- a/.github/workflows/vsphere-integration.yaml
+++ b/.github/workflows/vsphere-integration.yaml
@@ -21,11 +21,11 @@ jobs:
         with:
           provider: vsphere
           credentials-yaml: ${{ secrets.CREDENTIALS_YAML }}
+          charmcraft-channel: ${{ steps.charmcraft.outputs.channel }}
           clouds-yaml: ${{ secrets.CLOUDS_YAML }}
           bootstrap-constraints: "arch=amd64 cores=2 mem=4G"
           bootstrap-options: "${{ secrets.JAMMY_BOOTSTRAP_OPTIONS }} --model-default datastore=vsanDatastore --model-default primary-network=VLAN_2763 --config caas-image-repo=rocks.canonical.com/cdk/jujusolutions"
           juju-channel: "3/stable"
-          charmcraft-channel: "${{ steps.charmcraft.outputs.channel }}"
 
       - name: Run test
         run: tox -e integration -- --basetemp=/home/ubuntu/pytest

--- a/.github/workflows/vsphere-integration.yaml
+++ b/.github/workflows/vsphere-integration.yaml
@@ -28,7 +28,7 @@ jobs:
           charmcraft-channel: "${{ steps.charmcraft.outputs.channel }}"
 
       - name: Run test
-        run: tox -e func -- --basetemp=/home/ubuntu/pytest
+        run: tox -e integration -- --basetemp=/home/ubuntu/pytest
 
       - name: Setup Debug Artifact Collection
         if: ${{ failure() }}
@@ -41,7 +41,7 @@ jobs:
           mv juju-crashdump-* tmp/ | true
       - name: Upload debug artifacts
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-run-artifacts
           path: tmp

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,8 @@ ops.manifest >= 1.1.3, < 2.0
 jinja2
 pyyaml
 
+charm-lib-contextual-status @ git+https://github.com/charmed-kubernetes/charm-lib-contextual-status
+charm-lib-reconciler @ git+https://github.com/charmed-kubernetes/charm-lib-reconciler@main
 interface_ceph_client @ git+https://github.com/openstack/charm-ops-interface-ceph-client@d4d0cefc5e92edd28cdbf5d00e190d4498896418
 charmhelpers == 1.2.1
 setuptools == 69.5.1

--- a/src/charm.py
+++ b/src/charm.py
@@ -7,21 +7,20 @@ import configparser
 import json
 import logging
 import subprocess
-from functools import cached_property, lru_cache, wraps
+from functools import cached_property, lru_cache
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, cast
+from typing import Any, Dict, List, Optional, cast
 
+import charms.contextual_status as status
 import charms.operator_libs_linux.v0.apt as apt
+import ops
+from charms.reconciler import Reconciler
 from interface_ceph_client import ceph_client  # type: ignore
 from lightkube import Client, KubeConfig
-from lightkube.core.exceptions import ApiError, ConfigError
+from lightkube.core.exceptions import ApiError
 from lightkube.resources.core_v1 import Namespace
 from lightkube.resources.storage_v1 import StorageClass
-from ops.charm import ActionEvent, CharmBase, EventBase, UpdateStatusEvent
-from ops.framework import StoredState
-from ops.main import main
 from ops.manifests import Collector, ManifestClientError
-from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
 
 from manifests_base import Manifests, SafeManifest
 from manifests_cephfs import CephFSManifests, CephStorageClass
@@ -43,62 +42,34 @@ def ceph_keyring_file(app_name: str) -> Path:
     return ceph_config_dir() / f"ceph.client.{app_name}.keyring"
 
 
-def needs_leader(func: Callable) -> Callable:
-    """Ensure that function with this decorator is executed only if on leader units."""
-
-    @wraps(func)
-    def leader_check(self: CharmBase, *args: Any, **kwargs: Any) -> Any:
-        if self.unit.is_leader():
-            return func(self, *args, **kwargs)
-        logger.info(
-            "Execution of function '%s' skipped. This function can be executed only by the leader"
-            " unit.",
-            func.__name__,
-        )
-        return None
-
-    return leader_check
-
-
-class CephCsiCharm(CharmBase):
+class CephCsiCharm(ops.CharmBase):
     """Charm the service."""
 
     CEPH_CLIENT_RELATION = "ceph-client"
     REQUIRED_CEPH_POOLS = ["xfs-pool", "ext4-pool"]
     DEFAULT_NAMESPACE = "default"
 
-    stored = StoredState()
+    stored = ops.StoredState()
 
     def __init__(self, *args: Any) -> None:
         """Setup even observers and initial storage values."""
         super().__init__(*args)
         self.ceph_client = ceph_client.CephClientRequires(self, "ceph-client")
+
         self.framework.observe(
             self.ceph_client.on.broker_available, self._on_ceph_client_broker_available
         )
-        self.framework.observe(self.on.ceph_client_relation_changed, self._merge_config)
-        self.framework.observe(self.on.ceph_client_relation_broken, self._on_ceph_client_removed)
+        self.reconciler = Reconciler(self, self.reconcile)
 
         self.framework.observe(self.on.list_versions_action, self._list_versions)
         self.framework.observe(self.on.list_resources_action, self._list_resources)
         self.framework.observe(self.on.scrub_resources_action, self._scrub_resources)
         self.framework.observe(self.on.sync_resources_action, self._sync_resources)
         self.framework.observe(self.on.delete_storage_class_action, self._delete_storage_class)
-        self.framework.observe(self.on.update_status, self._update_status)
+        self.framework.observe(self.on.update_status, self._on_update_status)
 
-        self.framework.observe(self.on.install, self._on_install_or_upgrade)
-        self.framework.observe(self.on.upgrade_charm, self._on_install_or_upgrade)
-        self.framework.observe(self.on.leader_elected, self._merge_config)
-        self.framework.observe(self.on.config_changed, self._merge_config)
-        self.framework.observe(self.on.stop, self._cleanup)
-
-        self.framework.observe(self.on.kubernetes_info_relation_joined, self._merge_config)
-        self.framework.observe(self.on.kubernetes_info_relation_changed, self._merge_config)
-        self.framework.observe(self.on.kubernetes_info_relation_broken, self._merge_config)
-
-        self.stored.set_default(ceph_data={})
         self.stored.set_default(config_hash=0)  # hashed value of the provider config once valid
-        self.stored.set_default(deployed=False)  # True if config has been applied after new hash
+        self.stored.set_default(destroying=False)  # True when the charm is being shutdown
         self.stored.set_default(namespace=self._configured_ns)
 
         self.collector = Collector(
@@ -107,37 +78,20 @@ class CephCsiCharm(CharmBase):
             RBDManifests(self),
         )
 
-    @property
-    def _configured_ns(self) -> str:
-        """Currently configured namespace."""
-        return str(self.config.get("namespace") or self.DEFAULT_NAMESPACE)
-
-    def _ops_wait_for(self, event: EventBase, msg: str) -> str:
-        self.unit.status = WaitingStatus(msg)
-        if not isinstance(event, UpdateStatusEvent):
-            event.defer()
-        return msg
-
-    def _ops_blocked_by(self, msg: str, exc_info: bool = False) -> str:
-        self.unit.status = BlockedStatus(msg)
-        if exc_info:
-            logger.exception(msg)
-        return msg
-
-    def _list_versions(self, event: ActionEvent) -> None:
+    def _list_versions(self, event: ops.ActionEvent) -> None:
         self.collector.list_versions(event)
 
-    def _list_resources(self, event: ActionEvent) -> None:
+    def _list_resources(self, event: ops.ActionEvent) -> None:
         manifests = event.params.get("manifest", "")
         resources = event.params.get("resources", "")
         return self.collector.list_resources(event, manifests, resources)
 
-    def _scrub_resources(self, event: ActionEvent) -> None:
+    def _scrub_resources(self, event: ops.ActionEvent) -> None:
         manifests = event.params.get("manifest", "")
         resources = event.params.get("resources", "")
         return self.collector.scrub_resources(event, manifests, resources)
 
-    def _sync_resources(self, event: ActionEvent) -> None:
+    def _sync_resources(self, event: ops.ActionEvent) -> None:
         manifests = event.params.get("manifest", "")
         resources = event.params.get("resources", "")
         try:
@@ -149,7 +103,7 @@ class CephCsiCharm(CharmBase):
         else:
             self.stored.deployed = True
 
-    def _delete_storage_class(self, event: ActionEvent) -> None:
+    def _delete_storage_class(self, event: ops.ActionEvent) -> None:
         storage_class: Optional[str] = event.params.get("name")
         if storage_class not in ["cephfs", "ceph-xfs", "ceph-ext4"]:
             msg = "Invalid storage class name. Must be one of: cephfs, ceph-xfs, ceph-ext4"
@@ -165,61 +119,62 @@ class CephCsiCharm(CharmBase):
             event.fail(msg)
         else:
             event.set_results({"result": f"Successfully deleted StorageClass/{storage_class}"})
-            self.stored.deployed = True
 
-    def _update_status(self, event: EventBase) -> None:
-        if not cast(bool, self.stored.deployed):
-            self._merge_config(event)
-            return
-        self.unit.status = MaintenanceStatus("Updating Status")
-
+    def _update_status(self) -> None:
         unready = self.collector.unready
-        current_ns, config_ns = self.stored.namespace, self._configured_ns
         if unready:
-            self.unit.status = WaitingStatus(", ".join(unready))
-        elif current_ns != config_ns:
-            self._ops_blocked_by(f"Namespace '{current_ns}' cannot be configured to '{config_ns}'")
+            status.add(ops.WaitingStatus(", ".join(unready)))
+        elif self.stored.namespace != self._configured_ns:
+            status.add(ops.BlockedStatus("Namespace cannot be changed after deployment"))
         else:
-            self.unit.status = ActiveStatus("Unit is ready")
             self.unit.set_workload_version(self.collector.short_version)
             if self.unit.is_leader():
-                self.app.status = ActiveStatus(self.collector.long_version)
+                self.app.status = ops.ActiveStatus(self.collector.long_version)
+
+    def _on_update_status(self, _: ops.EventBase) -> None:
+        if not self.reconciler.stored.reconciled:
+            return
+        try:
+            with status.context(self.unit):
+                self._update_status()
+        except status.ReconcilerError:
+            logger.exception("Can't update_status")
 
     @property
-    def _ceph_data(self) -> Dict[str, Any]:
-        return cast(Dict[str, Any], self.stored.ceph_data)
+    def _configured_ns(self) -> str:
+        """Currently configured namespace."""
+        return str(self.config.get("namespace") or self.DEFAULT_NAMESPACE)
+
+    @property
+    def ceph_data(self) -> Dict[str, Any]:
+        """Return Ceph data from ceph-client relation"""
+        r_data = self.ceph_client.get_relation_data()
+        return {k: r_data.get(k) for k in ("auth", "key", "mon_hosts")}
 
     @property
     def auth(self) -> Optional[str]:
-        """Return stored Ceph auth mode from ceph-client relation"""
-        return self._ceph_data.get("auth")
+        """Return Ceph auth mode from ceph-client relation"""
+        return self.ceph_data["auth"]
 
     @property
     def key(self) -> Optional[str]:
-        """Return stored Ceph key from ceph-client relation"""
-        return self._ceph_data.get("key")
+        """Return Ceph key from ceph-client relation"""
+        return self.ceph_data["key"]
 
     @property
     def mon_hosts(self) -> List[str]:
-        """Return stored Ceph monitor hosts from ceph-client relation"""
-        return list(self._ceph_data.get("mon_hosts", []))
+        """Return Ceph monitor hosts from ceph-client relation"""
+        return self.ceph_data["mon_hosts"] or []
 
-    def _install_ceph_common(self) -> bool:
+    @status.on_error(ops.BlockedStatus("Failed to install ceph-common apt package."))
+    def install_ceph_common(self, event: ops.EventBase) -> None:
         """Install ceph-common apt package"""
-        self.unit.status = MaintenanceStatus("Installing Binaries")
-        packages = ["ceph-common"]
-        logger.info(f"Installing apt packages {', '.join(packages)}")
-        try:
-            # Run `apt-get update` and add packages
-            apt.add_package(packages, update_cache=True)
-        except apt.PackageNotFoundError:
-            self._ops_blocked_by("Apt packages not found.", exc_info=True)
-            return False
-        except apt.PackageError:
-            self._ops_blocked_by("Could not apt install packages.", exc_info=True)
-            return False
-
-        return True
+        self.unit.status = ops.MaintenanceStatus("Ensuring ceph-common package")
+        latest = isinstance(event, (ops.InstallEvent, ops.UpgradeCharmEvent))
+        state = apt.PackageState.Latest if latest else apt.PackageState.Present
+        ceph = apt.DebianPackage.from_system("ceph-common")
+        ceph.ensure(state)
+        logger.info("Installing ceph-common to version: %s", ceph.fullversion)
 
     def write_ceph_cli_config(self) -> None:
         """Write Ceph CLI .conf file"""
@@ -271,6 +226,7 @@ class CephCsiCharm(CharmBase):
             logger.error("get_ceph_fsid: Failed to get CephFS ID, reporting as empty string")
             return ""
 
+    @lru_cache(maxsize=None)
     def get_ceph_fsname(self) -> Optional[str]:
         """Get the Ceph FS Name."""
         try:
@@ -315,10 +271,9 @@ class CephCsiCharm(CharmBase):
     @cached_property
     def _client(self) -> Client:
         """Lightkube Client instance."""
-        client = Client(field_manager=f"{self.model.app.name}")
-        return client
+        return Client(field_manager=f"{self.model.app.name}")
 
-    @cached_property
+    @property
     def ceph_context(self) -> Dict[str, Any]:
         """Return context that can be used to render ceph resource files in templates/ folder."""
         return {
@@ -332,125 +287,71 @@ class CephCsiCharm(CharmBase):
             "fsname": self.get_ceph_fsname(),
         }
 
-    def _check_kube_config(self, event: EventBase) -> bool:
-        self.unit.status = MaintenanceStatus("Evaluating kubernetes authentication")
-        try:
-            KubeConfig.from_env()
-        except ConfigError:
-            self._ops_wait_for(event, "Waiting for kubeconfig")
-            return False
-        return True
+    @status.on_error(ops.WaitingStatus("Waiting for kubeconfig"))
+    def check_kube_config(self) -> None:
+        self.unit.status = ops.MaintenanceStatus("Evaluating kubernetes authentication")
+        KubeConfig.from_env()
 
-    def _check_namespace(self, event: EventBase, ns: str) -> bool:
-        self.unit.status = MaintenanceStatus("Evaluating namespace")
+    def check_namespace(self) -> None:
+        self.unit.status = ops.MaintenanceStatus("Evaluating namespace")
         try:
-            self._client.get(Namespace, name=ns)
+            self._client.get(Namespace, name=self.stored.namespace)  # type: ignore
         except ApiError as e:
             if "not found" in str(e.status.message):
-                self._ops_blocked_by(f"Missing namespace '{ns}'", exc_info=True)
-                event.defer()
-                return False
+                status.add(ops.BlockedStatus(f"Missing namespace '{self.stored.namespace}'"))
+                raise status.ReconcilerError("Namespace not found")
             else:
                 # surface any other errors besides not found
-                logger.exception(e)
-                self._ops_wait_for(event, "Waiting for Kubernetes API")
-                return False
-        return True
+                status.add(ops.WaitingStatus("Waiting for Kubernetes API"))
+                raise status.ReconcilerError("Waiting for Kubernetes API")
 
-    def _check_cephfs(self) -> bool:
-        self.unit.status = MaintenanceStatus("Evaluating CephFS capability")
-        if not self.config["cephfs-enable"]:
+    @status.on_error(ops.BlockedStatus("CephFS is not usable; set 'cephfs-enable=False'"))
+    def check_cephfs(self) -> None:
+        self.unit.status = ops.MaintenanceStatus("Evaluating CephFS capability")
+        disabled = self.config.get("cephfs-enable") is False
+        if disabled:
             # not enabled, not a problem
-            return True
-        if not self.ceph_context.get("fsname", None):
+            logger.info("CephFS is disabled")
+        elif not self.ceph_context.get("fsname", None):
             logger.error(
                 "Ceph CLI failed to find a CephFS fsname. Run 'juju config cephfs-enable=False' until ceph-fs is usable."
             )
-            self._ops_blocked_by("CephFS is not usable; set 'cephfs-enable=False'")
-            return False
-        return True
+            raise status.ReconcilerError("CephFS is not usable; set 'cephfs-enable=False'")
 
-    def _merge_config(self, event: EventBase) -> None:
-        if not self._check_required_relations():
-            return
+        if disabled and self.unit.is_leader():
+            self._purge_manifest_by_name("cephfs")
 
-        if not self._check_kube_config(event):
-            return
-
-        if not self._check_namespace(event, str(self.stored.namespace)):
-            return
-
-        if not self._check_cephfs():
-            return
-
-        self.unit.status = MaintenanceStatus("Evaluating Manifests")
+    def evaluate_manifests(self) -> int:
+        """Evaluate all manifests."""
+        self.unit.status = ops.MaintenanceStatus("Evaluating CephCSI")
         new_hash = 0
         for manifest in self.collector.manifests.values():
             manifest = cast(SafeManifest, manifest)
-            evaluation = manifest.evaluate()
-            if evaluation:
-                self.unit.status = BlockedStatus(evaluation)
-                return
+            if evaluation := manifest.evaluate():
+                status.add(ops.BlockedStatus(evaluation))
+                raise status.ReconcilerError(evaluation)
             new_hash += manifest.hash()
+        return new_hash
 
-        self.stored.deployed = False
-        if self._install_manifests(event, config_hash=new_hash):
-            self.stored.config_hash = new_hash
-            self.stored.deployed = True
-        self._update_status(event)
-
-    def _on_install_or_upgrade(self, event: EventBase) -> None:
-        """Execute "on install" event callback."""
-        no_error = self._install_ceph_common()
-        no_error = no_error and self._check_required_relations()
-        current_hash = no_error and self._install_manifests(event)
-        self.stored.deployed = False
-        if current_hash:
-            self.stored.config_hash = current_hash
-            self.stored.deployed = True
-
-    def _install_manifests(self, event: EventBase, config_hash: int = 0) -> int:
+    def install_manifests(self, config_hash: int) -> None:
         if cast(int, self.stored.config_hash) == config_hash:
             logger.info(f"No config changes detected. config_hash={config_hash}")
-            return config_hash
+            return
         if self.unit.is_leader():
-            self.unit.status = MaintenanceStatus("Deploying CephCSI")
+            self.unit.status = ops.MaintenanceStatus("Deploying CephCSI")
             self.unit.set_workload_version("")
             for manifest in self.collector.manifests.values():
                 try:
                     manifest.apply_manifests()
                 except ManifestClientError as e:
-                    self._ops_wait_for(event, " -> ".join(map(str, e.args)))
-                    logger.warning(f"Encountered retryable installation error: {e}")
-                    event.defer()
-                    return 0
+                    failure_msg = " -> ".join(map(str, e.args))
+                    status.add(ops.WaitingStatus(failure_msg))
+                    logger.warning("Encountered retriable installation error: %s", e)
+                    raise status.ReconcilerError(failure_msg)
 
-            disable_cephfs = not self.config["cephfs-enable"]
-            if disable_cephfs and not self._purge_manifest_by_name(event, "cephfs"):
-                # Failed to remove cephfs components when cephfs is disabled
-                # _purge should defer
-                return 0
+        self.stored.config_hash = config_hash
 
-        return config_hash
-
-    def _check_required_relations(self) -> bool:
-        """Run check if any required relations are missing"""
-        self.unit.status = MaintenanceStatus("Checking Relations")
-        required_relations = [self.CEPH_CLIENT_RELATION]
-        missing_relations = [
-            relation
-            for relation in required_relations
-            if self.model.get_relation(relation) is None
-        ]
-
-        if missing_relations:
-            evaluation = "Missing relations: {}".format(", ".join(missing_relations))
-            self.unit.status = BlockedStatus(evaluation)
-            return False
-
-        return self.safe_load_ceph_client_data()
-
-    def safe_load_ceph_client_data(self) -> bool:
+    def check_ceph_client(self) -> None:
         """Load data from ceph-mon:client relation and store it in StoredState.
 
         This method expects all the required data (key, mon_hosts) to be present in the
@@ -460,21 +361,36 @@ class CephCsiCharm(CharmBase):
         :param remote_unit: Unit instance representing remote ceph-mon unit.
         :return: `True` if all the data successfully loaded, otherwise `False`
         """
+        self.unit.status = ops.MaintenanceStatus("Checking Relations")
+        if not self.model.get_relation(self.CEPH_CLIENT_RELATION):
+            status.add(ops.BlockedStatus("Missing relation: ceph-client"))
+            raise status.ReconcilerError("Missing relation: ceph-client")
+
         relation_data = self.ceph_client.get_relation_data()
         expected_relation_keys = ("auth", "key", "mon_hosts")
 
         missing_data = [key for key in expected_relation_keys if key not in relation_data]
         if missing_data:
             logger.warning("Ceph relation is missing data: %s", missing_data)
-            self.unit.status = WaitingStatus("Ceph relation is missing data.")
-            success = False
-        else:
-            for relation_key in expected_relation_keys:
-                self._ceph_data[relation_key] = relation_data.get(relation_key)
-            success = True
-            self.configure_ceph_cli()
+            status.add(ops.WaitingStatus("Ceph relation is missing data."))
+            raise status.ReconcilerError("Ceph relation is missing data.")
 
-        return success
+    def reconcile(self, event: ops.EventBase) -> None:
+        """Reconcile the charm state."""
+        if self._destroying(event):
+            if self.unit.is_leader():
+                self._purge_all_manifests()
+            return
+
+        self.install_ceph_common(event)
+        self.check_kube_config()
+        self.check_namespace()
+        self.check_ceph_client()
+        self.configure_ceph_cli()
+        self.check_cephfs()
+        hash = self.evaluate_manifests()
+        self.install_manifests(config_hash=hash)
+        self._update_status()
 
     def request_ceph_pools(self) -> None:
         """Request creation of Ceph pools from the ceph-client relation"""
@@ -497,20 +413,19 @@ class CephCsiCharm(CharmBase):
         ]
         self.ceph_client.request_ceph_permissions(self.app.name, permissions)
 
-    def _on_ceph_client_broker_available(self, event: EventBase) -> None:
+    def _on_ceph_client_broker_available(self, event: ops.EventBase) -> None:
         """Use ceph-mon:client relation to request creation of ceph-pools and
         ceph user permissions
         """
         self.request_ceph_pools()
         self.request_ceph_permissions()
-        self._merge_config(event)
+        self.reconciler.reconcile(event)
 
-    @needs_leader
-    def _purge_all_manifests(self, event: EventBase) -> None:
+    def _purge_all_manifests(self) -> None:
         """Purge resources created by this charm."""
-        self.unit.status = MaintenanceStatus("Removing Kubernetes resources")
+        self.unit.status = ops.MaintenanceStatus("Removing Kubernetes resources")
         for manifest in self.collector.manifests.values():
-            if not self._purge_manifest(event, manifest):
+            if not self._purge_manifest(manifest):
                 return
         ceph_pools = ", ".join(self.REQUIRED_CEPH_POOLS)
         logger.warning(
@@ -518,42 +433,34 @@ class CephCsiCharm(CharmBase):
             "action 'delete-pool' on 'ceph-mon' units",
             ceph_pools,
         )
-        self.stored.deployed = False
+        self.stored.config_hash = 0
 
-    def _purge_manifest_by_name(self, event: EventBase, name: str) -> bool:
+    def _purge_manifest_by_name(self, name: str) -> None:
         """Purge resources created by this charm by manifest name."""
-        self.unit.status = MaintenanceStatus(f"Removing {name} resources")
+        self.unit.status = ops.MaintenanceStatus(f"Removing {name} resources")
         for manifest in self.collector.manifests.values():
             if manifest.name == name:
-                if not self._purge_manifest(event, manifest):
-                    return False
-        return True
+                self._purge_manifest(manifest)
 
-    def _purge_manifest(self, event: EventBase, manifest: Manifests) -> bool:
+    @status.on_error(ops.WaitingStatus("Manifest purge failed."))
+    def _purge_manifest(self, manifest: Manifests) -> None:
         """Purge resources created by this charm by manifest."""
-        try:
-            manifest = cast(SafeManifest, manifest)
-            manifest.purgeable = True
-            manifest.delete_manifests(ignore_unauthorized=True, ignore_not_found=True)
-            manifest.purgeable = False
-        except ManifestClientError:
-            self.unit.status = WaitingStatus("Waiting for kube-apiserver")
-            event.defer()
-            return False
-        return True
+        manifest = cast(SafeManifest, manifest)
+        manifest.purgeable = True
+        manifest.delete_manifests(ignore_unauthorized=True, ignore_not_found=True)
+        manifest.purgeable = False
 
-    def _on_ceph_client_removed(self, event: EventBase) -> None:
-        """Remove resources when relation removed"""
-        self._purge_all_manifests(event)
-        self._merge_config(event)
-
-    def _cleanup(self, event: EventBase) -> None:
-        """Remove resources when charm is stopped removed"""
-        if cast(bool, self.stored.deployed):
-            self.unit.status = MaintenanceStatus("Cleaning up...")
-            if self._purge_all_manifests(event):
-                self.unit.status = MaintenanceStatus("Shutting down")
+    def _destroying(self, event: ops.EventBase) -> bool:
+        """Check if the charm is being destroyed."""
+        if cast(bool, self.stored.destroying):
+            return True
+        if isinstance(event, (ops.StopEvent, ops.RemoveEvent)):
+            self.stored.destroying = True
+            return True
+        elif isinstance(event, ops.RelationBrokenEvent) and event.relation.name == "ceph-client":
+            return True
+        return False
 
 
 if __name__ == "__main__":  # pragma: no cover
-    main(CephCsiCharm)
+    ops.main.main(CephCsiCharm)

--- a/src/charm.py
+++ b/src/charm.py
@@ -124,6 +124,7 @@ class CephCsiCharm(ops.CharmBase):
         unready = self.collector.unready
         if unready:
             status.add(ops.WaitingStatus(", ".join(unready)))
+            raise status.ReconcilerError("Waiting for deployment")
         elif self.stored.namespace != self._configured_ns:
             status.add(ops.BlockedStatus("Namespace cannot be changed after deployment"))
         else:

--- a/tests/functional/test_ceph_csi.py
+++ b/tests/functional/test_ceph_csi.py
@@ -81,7 +81,8 @@ async def test_active_status(kube_config: Path, namespace: str, ops_test: OpsTes
         v1_namespace = client.V1Namespace(metadata=client.V1ObjectMeta(name=namespace))
         v1_core.create_namespace(v1_namespace)
 
-    await ops_test.model.wait_for_idle(wait_for_active=True, timeout=10 * 60, check_freq=5)
+    async with ops_test.fast_forward("60s"):
+        await ops_test.model.wait_for_idle(wait_for_active=True, timeout=15 * 60)
     for unit in ops_test.model.applications["ceph-csi"].units:
         assert unit.workload_status == "active"
         assert unit.workload_status_message == "Ready"

--- a/tests/functional/test_ceph_csi.py
+++ b/tests/functional/test_ceph_csi.py
@@ -84,7 +84,7 @@ async def test_active_status(kube_config: Path, namespace: str, ops_test: OpsTes
     await ops_test.model.wait_for_idle(wait_for_active=True, timeout=10 * 60, check_freq=5)
     for unit in ops_test.model.applications["ceph-csi"].units:
         assert unit.workload_status == "active"
-        assert unit.workload_status_message == "Unit is ready"
+        assert unit.workload_status_message == "Ready"
 
 
 async def test_deployment_replicas(kube_config: Path, namespace: str, ops_test):

--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -32,7 +32,7 @@ def wait_for_pod(
     core_api: client.CoreV1Api,
     name: str,
     namespace: str,
-    timeout: int = 60,
+    timeout: int = 120,
     target_state: str = "Running",
 ) -> None:
     """

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ commands =
     coverage run --source={toxinidir}/src -m pytest {toxinidir}/tests/unit/ {posargs}
     coverage report -m --fail-under=97
 
-[testenv:func]
+[testenv:integration]
 basepython = python3
 setenv =
     PYTHONPATH={toxinidir}/tests/functional/


### PR DESCRIPTION
## Overview

The patterns employed in this charm were difficult to reason about, and in some cases changes occur with no notifications to the charm via config changes or relation changes.  Because of this, it's better to employ this charm with a reconciler pattern which can check the necessary state of the charm before configuring/changing the cluster

### Details
* Adds the `charm-lib-reconciler` library
* Convert the `merge_config` method to act as the `reconciler` function
* Careful to not use any 1.30 branch reconciler feature so this could be backported to the 1.29 branch if necessary
* Greatly reduce unit testing
* Integration testing only changed to support a different "active" status message