### PR TITLE
Charm grows the ability to adjust storage class parameters

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -35,6 +35,30 @@ options:
       determined by probing for ceph-fuse and mount.ceph
     type: string
 
+  cephfs-storage-class-parameters:
+    default: ""
+    description: |
+      Parameters to be passed to the cephfs storage class.
+      Declare additional parameters in key=value format, separated by spaces.
+      Declare removed parameters in the key- format, separated by spaces.
+    type: string
+
+  ceph-xfs-storage-class-parameters:
+    default: ""
+    description: |
+      Parameters to be passed to the ceph-xfs storage class.
+      Declare additional parameters in key=value format, separated by spaces.
+      Declare removed parameters in the key- format, separated by spaces.
+    type: string
+
+  ceph-ext4-storage-class-parameters:
+    default: ""
+    description: |
+      Parameters to be passed to the ceph-ext4 storage class.
+      Declare additional parameters in key=value format, separated by spaces.
+      Declare removed parameters in the key- format, separated by spaces.
+    type: string
+
   namespace:
     type: string
     default: ""

--- a/src/manifests_base.py
+++ b/src/manifests_base.py
@@ -1,5 +1,6 @@
 import logging
 import pickle
+from abc import ABCMeta, abstractmethod
 from hashlib import md5
 from typing import Any, Dict, Optional
 
@@ -36,6 +37,14 @@ class AdjustNamespace(Patch):
 
 class StorageClassAddition(Addition):
     """Base class for storage class additions."""
+
+    __metaclass__ = ABCMeta
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Name of the storage class."""
+        raise NotImplementedError
 
     def update_parameters(self, parameters: Dict[str, str]) -> None:
         """Adjust parameters for storage class."""

--- a/tox.ini
+++ b/tox.ini
@@ -51,12 +51,11 @@ commands =
            {toxinidir}/tests/functional/
 
 [testenv:format]
-envdir = {toxworkdir}/lint
 basepython = python3
 commands =
     isort {[vars]all_path}
     black -l 99 {[vars]all_path}
-    ruff --fix {[vars]all_path}
+    ruff check --fix {[vars]all_path}
 
 [testenv:update]
 deps =
@@ -76,3 +75,4 @@ use_parentheses=True
 exclude_lines =
     pragma: no cover
     if TYPE_CHECKING
+    raise NotImplementedError


### PR DESCRIPTION
### Overview

Addresses [LP#2073297](https://launchpad.net/bugs/2073297) by allowing the ceph-csi charm to provision storage-class parameters of each of the Storage Classes created by this charm.

### Details

Creates three new config options:
- `cephfs-storage-class-parameters`
- `ceph-xfs-storage-class-parameters`
- `ceph-ext4-storage-class-parameters`

Each of these config options allows one to adjust the parameters of the storage class patched in by the charm.

Storage-Class parameters like these are not run-time updatable yet, but this can be set at charm deploy-time to correctly match any settings on any storage classes which exist in the cluster. 

For example)

You may deploy the charm like this:

```bash
juju deploy ceph-csi --channel=1.30/stable \
    --config ceph-xfs-storage-class-parameters='removed-key- custom-value=true'
```
