### PR TITLE
Adjust the UX of the storage class parameters feature

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -43,3 +43,16 @@ sync-resources:
         Space separated list of kubernetes resource types
         to use a filter during the sync. This helps limit
         which missing resources are applied.
+delete-storage-class:
+  description: |
+    Delete storage class which may be in conflict with the underlying cluster.
+  params:
+    name:
+      type: string
+      description: Name of a specific storage class to delete.
+      enum:
+        - cephfs
+        - ceph-xfs
+        - cephfs-ext4
+  required:
+  - name

--- a/config.yaml
+++ b/config.yaml
@@ -38,25 +38,40 @@ options:
   cephfs-storage-class-parameters:
     default: ""
     description: |
-      Parameters to be passed to the cephfs storage class.
-      Declare additional parameters in key=value format, separated by spaces.
+      Parameters to be used when creating the cephfs storage class.
+      Changes are only applied to the storage class if it does not exist.
+
+      Declare additional/replacement parameters in key=value format, separated by spaces.
       Declare removed parameters in the key- format, separated by spaces.
+
+      Optional parameters can be found in the ceph-csi documentation:
+      https://github.com/ceph/ceph-csi/blob/devel/examples/rbd/storageclass.yaml
     type: string
 
   ceph-xfs-storage-class-parameters:
-    default: ""
+    default: "imageFeatures=layering"
     description: |
-      Parameters to be passed to the ceph-xfs storage class.
-      Declare additional parameters in key=value format, separated by spaces.
+      Parameters to be used when creating the ceph-xfs storage class.
+      Changes are only applied to the storage class if it does not exist.
+
+      Declare additional/replacement parameters in key=value format, separated by spaces.
       Declare removed parameters in the key- format, separated by spaces.
+
+      Optional parameters can be found in the ceph-csi documentation:
+      https://github.com/ceph/ceph-csi/blob/devel/examples/rbd/storageclass.yaml
     type: string
 
   ceph-ext4-storage-class-parameters:
-    default: ""
+    default: "imageFeatures=layering"
     description: |
-      Parameters to be passed to the ceph-ext4 storage class.
-      Declare additional parameters in key=value format, separated by spaces.
+      Parameters to be used when creating the the ceph-ext4 storage class.
+      Changes are only applied to the storage class if it does not exist.
+
+      Declare additional/replacement parameters in key=value format, separated by spaces.
       Declare removed parameters in the key- format, separated by spaces.
+
+      Optional parameters can be found in the ceph-csi documentation:
+      https://github.com/ceph/ceph-csi/blob/devel/examples/rbd/storageclass.yaml
     type: string
 
   namespace:

--- a/src/manifests_rbd.py
+++ b/src/manifests_rbd.py
@@ -80,9 +80,7 @@ class CephStorageClass(StorageClassAddition):
             "csi.storage.k8s.io/node-stage-secret-namespace": ns,
             "csi.storage.k8s.io/provisioner-secret-name": StorageSecret.SECRET_NAME,
             "csi.storage.k8s.io/provisioner-secret-namespace": ns,
-            "imageFeatures": "layering",
             "pool": f"{self.fs_type}-pool",
-            "thickProvision": "false",
         }
 
         self.update_parameters(parameters)

--- a/tests/unit/test_manifests_rbd.py
+++ b/tests/unit/test_manifests_rbd.py
@@ -9,7 +9,7 @@ from lightkube.resources.storage_v1 import StorageClass
 from manifests_rbd import CephStorageClass, RBDManifests, StorageSecret
 
 
-def test_storage_secret_modeled(caplog):
+def test_storage_secret_modelled(caplog):
     caplog.set_level(logging.INFO)
     manifest = mock.MagicMock()
     ss = StorageSecret(manifest)
@@ -36,7 +36,7 @@ def test_storage_secret_modeled(caplog):
 
 
 @pytest.mark.parametrize("fs_type", ["xfs", "ext4"])
-def test_ceph_storage_class_modeled(caplog, fs_type):
+def test_ceph_storage_class_modelled(caplog, fs_type):
     caplog.set_level(logging.INFO)
     manifest = mock.MagicMock()
     manifest.config = {}
@@ -52,7 +52,11 @@ def test_ceph_storage_class_modeled(caplog, fs_type):
         "fsid": "abcd",
         "namespace": alt_ns,
         "default-storage": f"ceph-{fs_type}",
-        sc_params: "thickProvision- invalid-key extra-parameter=value",
+        sc_params: (
+            "missing-key- "  # removes the missing-key key
+            "invalid-key "  # skips the invalid-key key
+            "extra-parameter=value"  # adds the extra-parameter key
+        ),
     }
 
     expected = StorageClass(
@@ -70,9 +74,8 @@ def test_ceph_storage_class_modeled(caplog, fs_type):
             "csi.storage.k8s.io/node-stage-secret-namespace": alt_ns,
             "csi.storage.k8s.io/provisioner-secret-name": StorageSecret.SECRET_NAME,
             "csi.storage.k8s.io/provisioner-secret-namespace": alt_ns,
-            "extra-parameter": "value",
-            "imageFeatures": "layering",
             "pool": f"{csc.fs_type}-pool",
+            "extra-parameter": "value",
         },
         allowVolumeExpansion=True,
         mountOptions=["discard"],


### PR DESCRIPTION
# Update

### Overview

Addresses [LP#2073297](https://launchpad.net/bugs/2073297) by allowing the ceph-csi charm to provision storage-class parameters of each of the Storage Classes created by this charm.

### Details

1) Creates a delete-storage-class action

2) Updates three new config options:
- `cephfs-storage-class-parameters`
- `ceph-xfs-storage-class-parameters`
- `ceph-ext4-storage-class-parameters`

Each of these config options allows one to adjust the parameters of the storage class patched in by the charm.

Storage-Class parameters like these are not run-time updatable yet, but this can be set at charm deploy-time to correctly match any settings on any storage classes which exist in the cluster. 

For example)

You may deploy the charm like this:

```bash
juju deploy ceph-csi --channel=1.30/stable \
    --config ceph-xfs-storage-class-parameters='removed-key- custom-value=true'
```

This ensures that the best defaults possible are baked into the charm config
The charm managed parameters are removable and can be updated (while not recommended), but not listed in the charm config since the charm config doesn't support formatting the configured parameters.