### PR TITLE
[LP#2035399] Metrics Port configuration

### DIFF
--- a/.github/workflows/vsphere-integration.yaml
+++ b/.github/workflows/vsphere-integration.yaml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Read charmcraft version file
         id: charmcraft
-        run: echo "channel=$(cat .charmcraft-channel)" >> $GITHUB_OUTPUT
+        run: echo "channel=$(cat .charmcraft-channel)" >> $GITHUB_OUTPUT        
       - name: Setup Python
         uses: actions/setup-python@v4
         with:

--- a/config.yaml
+++ b/config.yaml
@@ -74,6 +74,38 @@ options:
       https://github.com/ceph/ceph-csi/blob/devel/examples/rbd/storageclass.yaml
     type: string
 
+  metrics-port-cephfsplugin:
+    default: -1
+    description: |
+      Port for csi-cephfsplugin liveness-prometheus metrics
+
+      If set to -1, the metrics service will not be created
+    type: int
+
+  metrics-port-cephfsplugin-provisioner:
+    default: -1
+    description: |
+      Port for csi-cephfsplugin-provisioner liveness-prometheus metrics
+
+      If set to -1, the metrics service will not be created
+    type: int
+
+  metrics-port-rbdplugin:
+    default: -1
+    description: |
+      Port for csi-rbdplugin liveness-prometheus metrics
+
+      If set to -1, the metrics service will not be created
+    type: int
+
+  metrics-port-rbdplugin-provisioner:
+    default: -1
+    description: |
+      Port for csi-rbdplugin-provisioner liveness-prometheus metrics
+
+      If set to -1, the metrics service will not be created
+    type: int
+
   namespace:
     type: string
     default: ""

--- a/src/manifests_base.py
+++ b/src/manifests_base.py
@@ -81,7 +81,11 @@ class ConfigureLivenessPrometheus(Patch):
 
             metrics_port_config = "metricsport"
             container.args = [
-                (f"--{metrics_port_config}={port}" if arg.startswith(f"--{metrics_port_config}=") else arg)
+                (
+                    f"--{metrics_port_config}={port}"
+                    if arg.startswith(f"--{metrics_port_config}=")
+                    else arg
+                )
                 for arg in container.args
             ]
             yield container

--- a/src/manifests_base.py
+++ b/src/manifests_base.py
@@ -2,7 +2,7 @@ import logging
 import pickle
 from abc import ABCMeta, abstractmethod
 from hashlib import md5
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Generator, Optional
 
 from lightkube.codecs import AnyResource
 from lightkube.core.resource import NamespacedResource
@@ -33,6 +33,56 @@ class AdjustNamespace(Patch):
         if isinstance(obj, NamespacedResource) and obj.metadata:
             ns = self.manifests.config["namespace"]
             obj.metadata.namespace = ns
+
+
+class ConfigureLivenessPrometheus(Patch):
+    """Configure liveness probe for Prometheus."""
+
+    def __init__(self, manifests: Manifests, kind: str, name: str, config: str) -> None:
+        super().__init__(manifests)
+        self.kind = kind
+        self.name = name
+        self.config = config
+
+    def __call__(self, obj: AnyResource) -> None:
+        """Configure liveness probe for Prometheus."""
+        if obj.kind != self.kind or not obj.metadata or obj.metadata.name != self.name:
+            return
+
+        if obj.kind in ["Deployment", "DaemonSet"]:
+            containers = self.filter_containers(obj.spec.template.spec.containers)
+            obj.spec.template.spec.containers = list(containers)
+        elif obj.kind == "Service":
+            mapping = self.filter_portmap(obj.spec.ports)
+            obj.spec.ports = list(mapping)
+
+    def filter_portmap(self, portmap: list) -> Generator:
+        """Update the http-metrics port mapping."""
+        port = self.manifests.config.get(f"metrics-port-{self.config}")
+        for mapping in portmap:
+            if mapping.name != "http-metrics":
+                yield mapping
+
+            if port != -1:
+                mapping.targetPort = port
+
+            yield mapping
+
+    def filter_containers(self, containers: list) -> Generator:
+        """Update the prometheus-liveness container."""
+        port = self.manifests.config.get(f"metrics-port-{self.config}")
+        for container in containers:
+            if container.name != "liveness-prometheus":
+                yield container
+
+            if port == -1:
+                continue
+
+            container.args = [
+                (f"--metricsport={port}" if arg.startswith("--metricsport=") else arg)
+                for arg in container.args
+            ]
+            yield container
 
 
 class StorageClassAddition(Addition):

--- a/src/manifests_cephfs.py
+++ b/src/manifests_cephfs.py
@@ -12,7 +12,12 @@ from lightkube.resources.storage_v1 import StorageClass
 from ops.manifests import Addition, ConfigRegistry, ManifestLabel, Patch
 from ops.manifests.manipulations import Subtraction
 
-from manifests_base import AdjustNamespace, SafeManifest, StorageClassAddition
+from manifests_base import (
+    AdjustNamespace,
+    ConfigureLivenessPrometheus,
+    SafeManifest,
+    StorageClassAddition,
+)
 
 if TYPE_CHECKING:
     from charm import CephCsiCharm
@@ -182,6 +187,16 @@ class CephFSManifests(SafeManifest):
                 RbacAdjustments(self),
                 RemoveCephFS(self),
                 AdjustNamespace(self),
+                ConfigureLivenessPrometheus(
+                    self, "Deployment", "csi-cephfsplugin-provisioner", "cephfsplugin-provisioner"
+                ),
+                ConfigureLivenessPrometheus(
+                    self, "Service", "csi-cephfsplugin-provisioner", "cephfsplugin-provisioner"
+                ),
+                ConfigureLivenessPrometheus(self, "DaemonSet", "csi-cephfsplugin", "cephfsplugin"),
+                ConfigureLivenessPrometheus(
+                    self, "Service", "csi-metrics-cephfsplugin", "cephfsplugin"
+                ),
             ],
         )
         self.charm = charm

--- a/src/manifests_config.py
+++ b/src/manifests_config.py
@@ -23,13 +23,15 @@ log = logging.getLogger(__name__)
 
 METRICS_PORT_CONFIG = "metrics-port"
 
+
 class InvalidMetricsPortError(Exception):
     pass
+
 
 def _validate_metrics_port(metrics_ports: Dict[str, int]) -> None:
     """
     Validate the metrics port.
-    
+
     Raises:
         InvalidMetricsPortError: If the metrics port is invalid (duplicate or not in range).
     """
@@ -42,10 +44,14 @@ def _validate_metrics_port(metrics_ports: Dict[str, int]) -> None:
         if value == -1:
             continue
 
-        if range_min <= value <= range_max: 
-            raise InvalidMetricsPortError(f"Invalid value for {conf}: {value}. Must be between {range_min} and {range_max}")
+        if range_min <= value <= range_max:
+            raise InvalidMetricsPortError(
+                f"Invalid value for {conf}: {value}. Must be between {range_min} and {range_max}"
+            )
         if value in unique_ports:
-            raise InvalidMetricsPortError(f"Value for {conf}: {value} conflicts with {unique_ports[value]}")
+            raise InvalidMetricsPortError(
+                f"Value for {conf}: {value} conflicts with {unique_ports[value]}"
+            )
         unique_ports[value] = conf
 
 

--- a/src/manifests_config.py
+++ b/src/manifests_config.py
@@ -21,6 +21,16 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
+METRICS_PORT_CONFIG = "metrics-port"
+
+
+def _valid_metrics_port(value: int) -> bool:
+    """Validate the metrics port."""
+    if value == -1:
+        return True
+    return 1024 <= value <= 65535
+
+
 class CephConfig(Addition):
     """Create configmap for the ceph-conf."""
 
@@ -128,4 +138,19 @@ class ConfigManifests(SafeManifest):
             value = self.config.get(prop)
             if not value:
                 return f"Config manifests require the definition of '{prop}'"
+
+        # Evaluate metrics port values
+        metrics_ports = {
+            conf: value
+            for conf, value in self.config.items()
+            if conf.startswith(METRICS_PORT_CONFIG)
+        }
+        unique_ports = {}
+        for conf, value in metrics_ports.items():
+            if not _valid_metrics_port(value):
+                return f"Invalid value for {conf}: {value}. Must be between 1024 and 65535"
+            if value != -1 and value in unique_ports:
+                return f"Value for {conf}: {value} conflicts with {unique_ports[value]}"
+            unique_ports[value] = conf
+
         return None

--- a/src/manifests_config.py
+++ b/src/manifests_config.py
@@ -39,12 +39,12 @@ def _validate_metrics_port(metrics_ports: Dict[str, int]) -> None:
     range_max = 65535
     unique_ports = {}
 
-    for conf, value in metrics_ports.items():
+    for conf, value in sorted(metrics_ports.items()):
         # -1 is default value hence skipped
         if value == -1:
             continue
 
-        if range_min <= value <= range_max:
+        if not (range_min <= value <= range_max):
             raise InvalidMetricsPortError(
                 f"Invalid value for {conf}: {value}. Must be between {range_min} and {range_max}"
             )

--- a/src/manifests_rbd.py
+++ b/src/manifests_rbd.py
@@ -10,7 +10,12 @@ from lightkube.resources.core_v1 import Secret
 from lightkube.resources.storage_v1 import StorageClass
 from ops.manifests import Addition, ConfigRegistry, ManifestLabel, Manifests, Patch
 
-from manifests_base import AdjustNamespace, SafeManifest, StorageClassAddition
+from manifests_base import (
+    AdjustNamespace,
+    ConfigureLivenessPrometheus,
+    SafeManifest,
+    StorageClassAddition,
+)
 
 if TYPE_CHECKING:
     from charm import CephCsiCharm
@@ -156,6 +161,14 @@ class RBDManifests(SafeManifest):
                 CephStorageClass(self, "ext4"),  # creates ceph-ext4
                 RbacAdjustments(self),
                 AdjustNamespace(self),
+                ConfigureLivenessPrometheus(
+                    self, "Deployment", "csi-rbdplugin-provisioner", "rbdplugin-provisioner"
+                ),
+                ConfigureLivenessPrometheus(
+                    self, "Service", "csi-rbdplugin-provisioner", "rbdplugin-provisioner"
+                ),
+                ConfigureLivenessPrometheus(self, "DaemonSet", "csi-rbdplugin", "rbdplugin"),
+                ConfigureLivenessPrometheus(self, "Service", "csi-metrics-rbdplugin", "rbdplugin"),
             ],
         )
         self.charm = charm

--- a/tests/unit/test_manifests_base.py
+++ b/tests/unit/test_manifests_base.py
@@ -1,0 +1,67 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from manifests_base import ConfigureLivenessPrometheus
+
+
+@pytest.fixture
+def mock_manifests():
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_obj():
+    return MagicMock()
+
+
+def test_liveness_prometheus_on_deployment_swap(mock_manifests, mock_obj, request):
+    config = "sample_config"
+    mock_manifests.config = {"metrics-port-sample_config": 8080}
+    mock_obj.kind = "Deployment"
+    mock_obj.metadata.name = name = request.node.name
+    mock_obj.spec.template.spec.containers = [MagicMock()]
+    mock_obj.spec.template.spec.containers[0].name = "liveness-prometheus"
+    mock_obj.spec.template.spec.containers[0].args = ["--metricsport=9090"]
+    liveness_prometheus = ConfigureLivenessPrometheus(mock_manifests, "Deployment", name, config)
+    liveness_prometheus(mock_obj)
+    assert mock_obj.spec.template.spec.containers[0].args == ["--metricsport=8080"]
+
+
+def test_liveness_prometheus_on_deployment_off(mock_manifests, mock_obj, request):
+    config = "sample_config"
+    mock_manifests.config = {"metrics-port-sample_config": -1}
+    mock_obj.kind = "Deployment"
+    mock_obj.metadata.name = name = request.node.name
+    mock_obj.spec.template.spec.containers = [MagicMock()]
+    mock_obj.spec.template.spec.containers[0].name = "liveness-prometheus"
+    mock_obj.spec.template.spec.containers[0].args = ["--metricsport=9090"]
+    liveness_prometheus = ConfigureLivenessPrometheus(mock_manifests, "Deployment", name, config)
+    liveness_prometheus(mock_obj)
+    assert not mock_obj.spec.template.spec.containers
+
+
+def test_liveness_prometheus_on_service_portmap_swap(mock_manifests, mock_obj, request):
+    config = "sample_config"
+    mock_manifests.config = {"metrics-port-sample_config": 8080}
+    mock_obj.kind = "Service"
+    mock_obj.metadata.name = name = request.node.name
+    mock_obj.spec.ports = [MagicMock()]
+    mock_obj.spec.ports[0].name = "http-metrics"
+    mock_obj.spec.ports[0].targetPort = 9090
+    liveness_prometheus = ConfigureLivenessPrometheus(mock_manifests, "Service", name, config)
+    liveness_prometheus(mock_obj)
+    assert mock_obj.spec.ports[0].targetPort == 8080
+
+
+def test_liveness_prometheus_on_service_portmap_off(mock_manifests, mock_obj, request):
+    config = "sample_config"
+    mock_manifests.config = {"metrics-port-sample_config": -1}
+    mock_obj.kind = "Service"
+    mock_obj.metadata.name = name = request.node.name
+    mock_obj.spec.ports = [MagicMock()]
+    mock_obj.spec.ports[0].name = "http-metrics"
+    mock_obj.spec.ports[0].targetPort = 9090
+    liveness_prometheus = ConfigureLivenessPrometheus(mock_manifests, "Service", name, config)
+    liveness_prometheus(mock_obj)
+    assert mock_obj.spec.ports[0].targetPort == 9090

--- a/tests/unit/test_manifests_cephfs.py
+++ b/tests/unit/test_manifests_cephfs.py
@@ -8,7 +8,7 @@ from lightkube.resources.storage_v1 import StorageClass
 from manifests_cephfs import CephFSManifests, CephStorageClass, StorageSecret
 
 
-def test_storage_secret_modeled(caplog):
+def test_storage_secret_modelled(caplog):
     caplog.set_level(logging.INFO)
     manifest = mock.MagicMock()
     ss = StorageSecret(manifest)
@@ -41,7 +41,7 @@ def test_storage_secret_modeled(caplog):
     assert "Modelling secret data for cephfs storage." in caplog.text
 
 
-def test_ceph_storage_class_modeled(caplog):
+def test_ceph_storage_class_modelled(caplog):
     caplog.set_level(logging.INFO)
     manifest = mock.MagicMock()
     csc = CephStorageClass(manifest)


### PR DESCRIPTION
### Overview

Addresses [LP#2035399](https://bugs.launchpad.net/charm-ceph-csi/+bug/2035399)
Provides charm config to adjust or disable the default metrics-ports used to expose metrics from the csi provisioners.


### Details
* The default manifests come with colliding port-numbers if enabled on host-networking
* Allows the admin to override the port-numbers in the event host-networking is enabled so they don't collide
* Defaults to Disabled, metrics will need to be enabled by selecting a port number that isn't `-1`