### PR TITLE
[Backport #24 to 1.31] [LP#2035399] Metrics Port configuration

### DIFF
--- a/.github/workflows/vsphere-integration.yaml
+++ b/.github/workflows/vsphere-integration.yaml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Read charmcraft version file
         id: charmcraft
-        run: echo "channel=$(cat .charmcraft-channel)" >> $GITHUB_OUTPUT
+        run: echo "channel=$(cat .charmcraft-channel)" >> $GITHUB_OUTPUT        
       - name: Setup Python
         uses: actions/setup-python@v4
         with:

--- a/config.yaml
+++ b/config.yaml
@@ -74,6 +74,38 @@ options:
       https://github.com/ceph/ceph-csi/blob/devel/examples/rbd/storageclass.yaml
     type: string
 
+  metrics-port-cephfsplugin:
+    default: -1
+    description: |
+      Port for csi-cephfsplugin liveness-prometheus metrics
+
+      If set to -1, the metrics service will not be created
+    type: int
+
+  metrics-port-cephfsplugin-provisioner:
+    default: -1
+    description: |
+      Port for csi-cephfsplugin-provisioner liveness-prometheus metrics
+
+      If set to -1, the metrics service will not be created
+    type: int
+
+  metrics-port-rbdplugin:
+    default: -1
+    description: |
+      Port for csi-rbdplugin liveness-prometheus metrics
+
+      If set to -1, the metrics service will not be created
+    type: int
+
+  metrics-port-rbdplugin-provisioner:
+    default: -1
+    description: |
+      Port for csi-rbdplugin-provisioner liveness-prometheus metrics
+
+      If set to -1, the metrics service will not be created
+    type: int
+
   namespace:
     type: string
     default: ""

--- a/src/manifests_cephfs.py
+++ b/src/manifests_cephfs.py
@@ -12,7 +12,12 @@ from lightkube.resources.storage_v1 import StorageClass
 from ops.manifests import Addition, ConfigRegistry, ManifestLabel, Patch
 from ops.manifests.manipulations import Subtraction
 
-from manifests_base import AdjustNamespace, SafeManifest, StorageClassAddition
+from manifests_base import (
+    AdjustNamespace,
+    ConfigureLivenessPrometheus,
+    SafeManifest,
+    StorageClassAddition,
+)
 
 if TYPE_CHECKING:
     from charm import CephCsiCharm
@@ -182,6 +187,16 @@ class CephFSManifests(SafeManifest):
                 RbacAdjustments(self),
                 RemoveCephFS(self),
                 AdjustNamespace(self),
+                ConfigureLivenessPrometheus(
+                    self, "Deployment", "csi-cephfsplugin-provisioner", "cephfsplugin-provisioner"
+                ),
+                ConfigureLivenessPrometheus(
+                    self, "Service", "csi-cephfsplugin-provisioner", "cephfsplugin-provisioner"
+                ),
+                ConfigureLivenessPrometheus(self, "DaemonSet", "csi-cephfsplugin", "cephfsplugin"),
+                ConfigureLivenessPrometheus(
+                    self, "Service", "csi-metrics-cephfsplugin", "cephfsplugin"
+                ),
             ],
         )
         self.charm = charm

--- a/src/manifests_rbd.py
+++ b/src/manifests_rbd.py
@@ -10,7 +10,12 @@ from lightkube.resources.core_v1 import Secret
 from lightkube.resources.storage_v1 import StorageClass
 from ops.manifests import Addition, ConfigRegistry, ManifestLabel, Manifests, Patch
 
-from manifests_base import AdjustNamespace, SafeManifest, StorageClassAddition
+from manifests_base import (
+    AdjustNamespace,
+    ConfigureLivenessPrometheus,
+    SafeManifest,
+    StorageClassAddition,
+)
 
 if TYPE_CHECKING:
     from charm import CephCsiCharm
@@ -156,6 +161,14 @@ class RBDManifests(SafeManifest):
                 CephStorageClass(self, "ext4"),  # creates ceph-ext4
                 RbacAdjustments(self),
                 AdjustNamespace(self),
+                ConfigureLivenessPrometheus(
+                    self, "Deployment", "csi-rbdplugin-provisioner", "rbdplugin-provisioner"
+                ),
+                ConfigureLivenessPrometheus(
+                    self, "Service", "csi-rbdplugin-provisioner", "rbdplugin-provisioner"
+                ),
+                ConfigureLivenessPrometheus(self, "DaemonSet", "csi-rbdplugin", "rbdplugin"),
+                ConfigureLivenessPrometheus(self, "Service", "csi-metrics-rbdplugin", "rbdplugin"),
             ],
         )
         self.charm = charm

--- a/tests/unit/test_manifests_base.py
+++ b/tests/unit/test_manifests_base.py
@@ -1,0 +1,67 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from manifests_base import ConfigureLivenessPrometheus
+
+
+@pytest.fixture
+def mock_manifests():
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_obj():
+    return MagicMock()
+
+
+def test_liveness_prometheus_on_deployment_swap(mock_manifests, mock_obj, request):
+    config = "sample_config"
+    mock_manifests.config = {"metrics-port-sample_config": 8080}
+    mock_obj.kind = "Deployment"
+    mock_obj.metadata.name = name = request.node.name
+    mock_obj.spec.template.spec.containers = [MagicMock()]
+    mock_obj.spec.template.spec.containers[0].name = "liveness-prometheus"
+    mock_obj.spec.template.spec.containers[0].args = ["--metricsport=9090"]
+    liveness_prometheus = ConfigureLivenessPrometheus(mock_manifests, "Deployment", name, config)
+    liveness_prometheus(mock_obj)
+    assert mock_obj.spec.template.spec.containers[0].args == ["--metricsport=8080"]
+
+
+def test_liveness_prometheus_on_deployment_off(mock_manifests, mock_obj, request):
+    config = "sample_config"
+    mock_manifests.config = {"metrics-port-sample_config": -1}
+    mock_obj.kind = "Deployment"
+    mock_obj.metadata.name = name = request.node.name
+    mock_obj.spec.template.spec.containers = [MagicMock()]
+    mock_obj.spec.template.spec.containers[0].name = "liveness-prometheus"
+    mock_obj.spec.template.spec.containers[0].args = ["--metricsport=9090"]
+    liveness_prometheus = ConfigureLivenessPrometheus(mock_manifests, "Deployment", name, config)
+    liveness_prometheus(mock_obj)
+    assert not mock_obj.spec.template.spec.containers
+
+
+def test_liveness_prometheus_on_service_portmap_swap(mock_manifests, mock_obj, request):
+    config = "sample_config"
+    mock_manifests.config = {"metrics-port-sample_config": 8080}
+    mock_obj.kind = "Service"
+    mock_obj.metadata.name = name = request.node.name
+    mock_obj.spec.ports = [MagicMock()]
+    mock_obj.spec.ports[0].name = "http-metrics"
+    mock_obj.spec.ports[0].targetPort = 9090
+    liveness_prometheus = ConfigureLivenessPrometheus(mock_manifests, "Service", name, config)
+    liveness_prometheus(mock_obj)
+    assert mock_obj.spec.ports[0].targetPort == 8080
+
+
+def test_liveness_prometheus_on_service_portmap_off(mock_manifests, mock_obj, request):
+    config = "sample_config"
+    mock_manifests.config = {"metrics-port-sample_config": -1}
+    mock_obj.kind = "Service"
+    mock_obj.metadata.name = name = request.node.name
+    mock_obj.spec.ports = [MagicMock()]
+    mock_obj.spec.ports[0].name = "http-metrics"
+    mock_obj.spec.ports[0].targetPort = 9090
+    liveness_prometheus = ConfigureLivenessPrometheus(mock_manifests, "Service", name, config)
+    liveness_prometheus(mock_obj)
+    assert mock_obj.spec.ports[0].targetPort == 9090

--- a/tests/unit/test_manifests_cephfs.py
+++ b/tests/unit/test_manifests_cephfs.py
@@ -8,7 +8,7 @@ from lightkube.resources.storage_v1 import StorageClass
 from manifests_cephfs import CephFSManifests, CephStorageClass, StorageSecret
 
 
-def test_storage_secret_modeled(caplog):
+def test_storage_secret_modelled(caplog):
     caplog.set_level(logging.INFO)
     manifest = mock.MagicMock()
     ss = StorageSecret(manifest)
@@ -41,7 +41,7 @@ def test_storage_secret_modeled(caplog):
     assert "Modelling secret data for cephfs storage." in caplog.text
 
 
-def test_ceph_storage_class_modeled(caplog):
+def test_ceph_storage_class_modelled(caplog):
     caplog.set_level(logging.INFO)
     manifest = mock.MagicMock()
     csc = CephStorageClass(manifest)


### PR DESCRIPTION
Backports https://github.com/charmed-kubernetes/ceph-csi-operator/pull/24


* Introduce config to disable or change the container port where the various prometheus-liveness metrics are exposed
* Minor refactor of port validation
* Test metrics port config