### PR TITLE
Create charm tolerations for ceph-rbd and cephfs deployments and daemonsets

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -48,6 +48,28 @@ options:
       https://github.com/ceph/ceph-csi/blob/devel/examples/rbd/storageclass.yaml
     type: string
 
+  cephfs-tolerations:
+    default: "=,Exists"
+    description: |
+      Tolerations to be used when creating the cephfs pods for Daemonsets and Deployments.
+
+      Declare tolerations in key=value,operator,effect format, separating each by spaces.
+
+      Optional tolerations can be found in the kubernetes documentation:
+      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+    type: string
+
+  ceph-rbd-tolerations:
+    default: ""
+    description: |
+      Tolerations to be used when creating the rbd pods for Daemonsets and Deployments.
+
+      Declare tolerations in key=value,operator,effect format, separating each by spaces.
+
+      Optional tolerations can be found in the kubernetes documentation:
+      https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+    type: string
+
   ceph-xfs-storage-class-parameters:
     default: "imageFeatures=layering"
     description: |

--- a/config.yaml
+++ b/config.yaml
@@ -49,7 +49,7 @@ options:
     type: string
 
   cephfs-tolerations:
-    default: "=,Exists"
+    default: "$csi-cephfsplugin-legacy$"
     description: |
       Tolerations to be used when creating the cephfs pods for Daemonsets and Deployments.
 
@@ -57,6 +57,10 @@ options:
 
       Optional tolerations can be found in the kubernetes documentation:
       https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+
+      Note:  The default value "$csi-cephfsplugin-legacy$" is a special token
+      which applies a "=,Exists" toleration only to pods associated with
+      csi-cephfsplugin.
     type: string
 
   ceph-rbd-tolerations:

--- a/src/manifests_base.py
+++ b/src/manifests_base.py
@@ -2,7 +2,7 @@ import logging
 import pickle
 from abc import ABCMeta, abstractmethod
 from hashlib import md5
-from typing import Any, Dict, Generator, List, Optional, Tuple
+from typing import Any, Dict, Generator, List, Optional
 
 from lightkube.codecs import AnyResource
 from lightkube.core.resource import NamespacedResource
@@ -123,7 +123,7 @@ class StorageClassAddition(Addition):
 
 class CephToleration(Toleration):
     @classmethod
-    def from_string(cls, toleration_str: str) -> "CephToleration":
+    def _from_string(cls, toleration_str: str) -> "CephToleration":
         """Parses a toleration string into a Toleration object.
 
         Raises:
@@ -150,11 +150,13 @@ class CephToleration(Toleration):
         )
 
     @classmethod
-    def from_comma_separated(
-        cls, tolerations: str
-    ) -> Tuple[List["CephToleration"], Optional[str]]:
-        """Parses a comma separated string of tolerations into a list of Toleration objects."""
+    def from_space_separated(cls, tolerations: str) -> List["CephToleration"]:
+        """Parses a space separated string of tolerations into a list of Toleration objects.
+
+        Raises:
+            ValueError: If any of the tolerations are invalid
+        """
         try:
-            return [cls.from_string(toleration) for toleration in tolerations.split()], None
+            return [cls._from_string(toleration) for toleration in tolerations.split()]
         except ValueError as e:
-            return [], f"Invalid tolerations: {e}"
+            raise ValueError(f"Invalid tolerations: {e}") from e

--- a/tests/unit/test_manifests_cephfs.py
+++ b/tests/unit/test_manifests_cephfs.py
@@ -115,3 +115,21 @@ def test_manifest_evaluation(caplog):
         "kubernetes_key": "123",
     }
     assert manifests.evaluate() is None
+
+    charm.config["cephfs-tolerations"] = "key=value,Foo"
+    assert (
+        manifests.evaluate()
+        == "Cannot adjust CephFS Pods: Invalid tolerations: Invalid operator='Foo'"
+    )
+
+    charm.config["cephfs-tolerations"] = "key=value,Exists,Foo"
+    assert (
+        manifests.evaluate()
+        == "Cannot adjust CephFS Pods: Invalid tolerations: Invalid effect='Foo'"
+    )
+
+    charm.config["cephfs-tolerations"] = "key=value,Exists,NoSchedule,Foo"
+    assert (
+        manifests.evaluate()
+        == "Cannot adjust CephFS Pods: Invalid tolerations: Too many effects='NoSchedule,Foo'"
+    )

--- a/tests/unit/test_manifests_rbd.py
+++ b/tests/unit/test_manifests_rbd.py
@@ -94,3 +94,21 @@ def test_manifest_evaluation(caplog):
 
     charm.config = {"user": "cephx", "fsid": "cluster", "kubernetes_key": "123"}
     assert manifests.evaluate() is None
+
+    charm.config["ceph-rbd-tolerations"] = "key=value,Foo"
+    assert (
+        manifests.evaluate()
+        == "Cannot adjust CephRBD Pods: Invalid tolerations: Invalid operator='Foo'"
+    )
+
+    charm.config["ceph-rbd-tolerations"] = "key=value,Exists,Foo"
+    assert (
+        manifests.evaluate()
+        == "Cannot adjust CephRBD Pods: Invalid tolerations: Invalid effect='Foo'"
+    )
+
+    charm.config["ceph-rbd-tolerations"] = "key=value,Exists,NoSchedule,Foo"
+    assert (
+        manifests.evaluate()
+        == "Cannot adjust CephRBD Pods: Invalid tolerations: Too many effects='NoSchedule,Foo'"
+    )


### PR DESCRIPTION
### Overview
* adds two config options to assign tolerations to the pods created by the Deployments and DaemonSets
* Validation of the user tolerations
