### PR TITLE
fix: purge any cephfs storage classes installed by ops.manifest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ops >= 1.2.0
-ops.manifest >= 1.1.3, < 2.0
+ops.manifest >= 1.5.0, < 2.0
 jinja2
 pyyaml
 

--- a/src/manifests_cephfs.py
+++ b/src/manifests_cephfs.py
@@ -4,7 +4,7 @@
 
 import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, cast
 
 from lightkube.codecs import AnyResource
 from lightkube.resources.core_v1 import Secret
@@ -174,6 +174,11 @@ class CephStorageClass(Addition):
 
     def __call__(self) -> List[AnyResource]:
         """Craft the storage class object."""
+        if cast(SafeManifest, self.manifests).purgeable:
+            # If we are purging, we may not be able to create any storage classes
+            # Just return a fake storage class to satisfy delete_manifests method
+            # which will look up all storage classes installed by this app/manifest
+            return [StorageClass.from_dict(dict(metadata={}, provisioner=self.PROVISIONER))]
         return [self.create(class_param) for class_param in self.parameter_list()]
 
 

--- a/tests/unit/test_manifests_cephfs.py
+++ b/tests/unit/test_manifests_cephfs.py
@@ -101,6 +101,7 @@ def test_ceph_provisioner_adjustment_modelled(caplog):
 def test_ceph_storage_class_modelled(caplog):
     caplog.set_level(logging.INFO)
     manifest = mock.MagicMock()
+    manifest.purgeable = False
     csc = CephStorageClass(manifest)
     alt_ns = "diff-ns"
 
@@ -138,6 +139,20 @@ def test_ceph_storage_class_modelled(caplog):
     )
     assert csc() == [expected]
     assert f"Modelling storage class sc='{TEST_CEPH_FS_ALT.name}'" in caplog.text
+
+
+def test_ceph_storage_class_purgeable(caplog):
+    caplog.set_level(logging.INFO)
+    manifest = mock.MagicMock()
+    manifest.purgeable = True
+    csc = CephStorageClass(manifest)
+
+    caplog.clear()
+    expected = StorageClass(
+        metadata=ObjectMeta(),
+        provisioner=CephStorageClass.PROVISIONER,
+    )
+    assert csc() == [expected]
 
 
 def test_manifest_evaluation(caplog):


### PR DESCRIPTION
fix: Purge cephfs storage class purging by purging only those SCs labelled by this app and manifest

Addresses [LP#2098004](https://bugs.launchpad.net/charm-ceph-csi/+bug/2098004)

Depends on
* https://github.com/canonical/ops-lib-manifest/pull/36