### PR TITLE
Create a formatter for cluster role and cluster role binding formatting

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -141,6 +141,21 @@ config:
         https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
       type: string
 
+    ceph-xfs-storage-class-name-formatter:
+      default: "ceph-xfs"
+      description: |
+        Formatter for the ceph xfs storage class name
+
+        The formatter is a string that can contain the following placeholders:
+          - {app}              - the name of the juju application
+          - {namespace}        - the charm configured namespace
+
+        Example:
+          juju config ceph-csi ceph-xfs-storage-class-name-formatter="{cluster}-{namespace}-{storageclass}"
+
+        The default is to use the storage class name
+      type: string
+
     ceph-xfs-storage-class-parameters:
       default: "imageFeatures=layering"
       description: |
@@ -152,6 +167,21 @@ config:
 
         Optional parameters can be found in the ceph-csi documentation:
         https://github.com/ceph/ceph-csi/blob/devel/examples/rbd/storageclass.yaml
+      type: string
+
+    ceph-ext4-storage-class-name-formatter:
+      default: "ceph-ext4"
+      description: |
+        Formatter for the ceph ext4 storage class name
+
+        The formatter is a string that can contain the following placeholders:
+          - {app}              - the name of the juju application
+          - {namespace}        - the charm configured namespace
+
+        Example:
+          juju config ceph-csi ceph-ext4-storage-class-name-formatter="{cluster}-{namespace}-{storageclass}"
+
+        The default is to use the storage class name
       type: string
 
     ceph-ext4-storage-class-parameters:
@@ -187,8 +217,9 @@ config:
           - ClusterRoleBinding/rbd-csi-provisioner-role
 
         The formatter is a string that can contain the following placeholders:
-          - {app}   - the name of the juju application
-          - {name}  - the charm configured namespace
+          - {app}       - the name of the juju application
+          - {name}      - the name of the kubernetes resource
+          - {namespace} - the charm configured namespace
 
         Example:
           juju config ceph-csi ceph-rbac-name-formatter="{name}-{app}"

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -167,6 +167,35 @@ config:
         https://github.com/ceph/ceph-csi/blob/devel/examples/rbd/storageclass.yaml
       type: string
 
+    ceph-rbac-name-formatter:
+      default: "{name}"
+      description: |
+        Formatter for colliding kubernetes rbac resources
+
+        The formatter is used to create a unique name for the resource
+        when the name collides with an existing resource.
+        This is useful when deploying multiple ceph-csi charms.
+
+        This is a list of non-namespaced resources affected by this formatter:
+          - ClusterRole/cephfs-csi-nodeplugin
+          - ClusterRoleBinding/cephfs-csi-nodeplugin
+          - ClusterRole/cephfs-external-provisioner-runner
+          - ClusterRoleBinding/cephfs-external-provisioner-runner
+          - ClusterRole/rbd-csi-nodeplugin
+          - ClusterRoleBinding/rbd-csi-nodeplugin
+          - ClusterRole/rbd-external-provisioner-runner
+          - ClusterRoleBinding/rbd-csi-provisioner-role
+
+        The formatter is a string that can contain the following placeholders:
+          - {app}   - the name of the juju application
+          - {name}  - the charm configured namespace
+
+        Example:
+          juju config ceph-csi ceph-rbac-name-formatter="{name}-{app}"
+
+        The default is to use the {name} of the resource
+      type: string
+
     image-registry:
       type: string
       default: "rocks.canonical.com/cdk"

--- a/src/manifests_base.py
+++ b/src/manifests_base.py
@@ -68,9 +68,14 @@ class RbacAdjustments(Patch):
 
         if obj.kind in ["ClusterRoleBinding", "RoleBinding"]:
             for each in obj.subjects:
+                # RoleBinding and ClusterRoleBinding subjects
+                # reference ServiceAccount in a different namespace
+                # so we need to set the namespace to the one we are deploying
                 if each.kind == "ServiceAccount":
                     each.namespace = ns
             if obj.roleRef.kind == "ClusterRole":
+                # ClusterRoleBinding roleRef references a ClusterRole
+                # which is not namespaced and has been renamed
                 obj.roleRef.name = self._rename(obj.roleRef.name)
 
 

--- a/src/manifests_cephfs.py
+++ b/src/manifests_cephfs.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, cast
 from lightkube.codecs import AnyResource
 from lightkube.resources.core_v1 import Secret
 from lightkube.resources.storage_v1 import StorageClass
-from ops.manifests import Addition, ConfigRegistry, Manifests, Patch
+from ops.manifests import Addition, ConfigRegistry, Patch
 from ops.manifests.manipulations import Subtraction
 
 from manifests_base import (
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     from charm import CephCsiCharm
 
 log = logging.getLogger(__name__)
+STORAGE_TYPE = "cephfs"
 
 
 @dataclass
@@ -83,13 +84,9 @@ class StorageSecret(Addition):
 class CephStorageClass(StorageClassFactory):
     """Create ceph storage classes."""
 
-    STORAGE_TYPE = "cephfs"
     FILESYSTEM_LISTING = "fs_list"
     REQUIRED_CONFIG = {"fsid", FILESYSTEM_LISTING}
     PROVISIONER = "cephfs.csi.ceph.com"
-
-    def __init__(self, manifests: Manifests):
-        super().__init__(manifests, self.STORAGE_TYPE)
 
     def create(self, param: CephStorageClassParameters) -> AnyResource:
         """Create a storage class object."""
@@ -264,7 +261,7 @@ class CephFSManifests(SafeManifest):
 
     def __init__(self, charm: "CephCsiCharm"):
         super().__init__(
-            "cephfs",
+            STORAGE_TYPE,
             charm.model,
             "upstream/cephfs",
             [
@@ -272,7 +269,7 @@ class CephFSManifests(SafeManifest):
                 ManifestLabelExcluder(self),
                 ConfigRegistry(self),
                 ProvisionerAdjustments(self),
-                CephStorageClass(self),
+                CephStorageClass(self, STORAGE_TYPE),
                 RbacAdjustments(self),
                 RemoveCephFS(self),
                 AdjustNamespace(self),

--- a/src/manifests_rbd.py
+++ b/src/manifests_rbd.py
@@ -3,7 +3,7 @@
 """Implementation of rbd specific details of the kubernetes manifests."""
 
 import logging
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, cast
+from typing import TYPE_CHECKING, Dict, List, Optional, cast
 
 from lightkube.codecs import AnyResource
 from lightkube.resources.core_v1 import Secret
@@ -73,12 +73,11 @@ class CephStorageClass(StorageClassFactory):
             return None
 
         ns = self.manifests.config["namespace"]
-        name = self.name()
-        metadata: Dict[str, Any] = dict(name=name)
-        if self.manifests.config.get("default-storage") == name:
+        metadata: Dict = {"name": self.name()}
+        if self.manifests.config.get("default-storage") == metadata["name"]:
             metadata["annotations"] = {"storageclass.kubernetes.io/is-default-class": "true"}
 
-        log.info(f"Modelling storage class {name}")
+        log.info(f"Modelling storage class {metadata['name']}")
         parameters = {
             "clusterID": clusterID,
             "csi.storage.k8s.io/controller-expand-secret-name": StorageSecret.SECRET_NAME,

--- a/src/manifests_rbd.py
+++ b/src/manifests_rbd.py
@@ -3,12 +3,12 @@
 """Implementation of rbd specific details of the kubernetes manifests."""
 
 import logging
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, cast
 
 from lightkube.codecs import AnyResource
 from lightkube.resources.core_v1 import Secret
 from lightkube.resources.storage_v1 import StorageClass
-from ops.manifests import Addition, ConfigRegistry, Manifests, Patch
+from ops.manifests import Addition, ConfigRegistry, Patch
 
 from manifests_base import (
     AdjustNamespace,
@@ -17,7 +17,7 @@ from manifests_base import (
     ManifestLabelExcluder,
     RbacAdjustments,
     SafeManifest,
-    update_storage_params,
+    StorageClassFactory,
 )
 
 if TYPE_CHECKING:
@@ -52,46 +52,46 @@ class StorageSecret(Addition):
         )
 
 
-class CephStorageClass(Addition):
+class CephStorageClass(StorageClassFactory):
     """Create ceph storage classes."""
 
     REQUIRED_CONFIG = {"fsid"}
     PROVISIONER = "rbd.csi.ceph.com"
 
-    def __init__(self, manifests: Manifests, fs_type: str):
-        super().__init__(manifests)
-        self.fs_type = fs_type
-
-    @property
-    def name(self) -> str:
-        return f"ceph-{self.fs_type}"
-
     def __call__(self) -> Optional[AnyResource]:
         """Craft the storage class object."""
+        if cast(SafeManifest, self.manifests).purging:
+            # If we are purging, we may not be able to create any storage classes
+            # Just return a fake storage class to satisfy delete_manifests method
+            # which will look up all storage classes installed by this app/manifest
+            return StorageClass.from_dict(dict(metadata={}, provisioner=self.PROVISIONER))
+
         clusterID = self.manifests.config.get("fsid")
+        fs_type = self._fs_type.split("-")[1]
         if not clusterID:
-            log.error(f"Ceph {self.fs_type.capitalize()} is missing required storage item: 'fsid'")
+            log.error(f"Ceph {fs_type.capitalize()} is missing required storage item: 'fsid'")
             return None
 
         ns = self.manifests.config["namespace"]
-        metadata: Dict[str, Any] = dict(name=self.name)
-        if self.manifests.config.get("default-storage") == self.name:
+        name = self.name()
+        metadata: Dict[str, Any] = dict(name=name)
+        if self.manifests.config.get("default-storage") == name:
             metadata["annotations"] = {"storageclass.kubernetes.io/is-default-class": "true"}
 
-        log.info(f"Modelling storage class {metadata['name']}")
+        log.info(f"Modelling storage class {name}")
         parameters = {
             "clusterID": clusterID,
             "csi.storage.k8s.io/controller-expand-secret-name": StorageSecret.SECRET_NAME,
             "csi.storage.k8s.io/controller-expand-secret-namespace": ns,
-            "csi.storage.k8s.io/fstype": self.fs_type,
+            "csi.storage.k8s.io/fstype": fs_type,
             "csi.storage.k8s.io/node-stage-secret-name": StorageSecret.SECRET_NAME,
             "csi.storage.k8s.io/node-stage-secret-namespace": ns,
             "csi.storage.k8s.io/provisioner-secret-name": StorageSecret.SECRET_NAME,
             "csi.storage.k8s.io/provisioner-secret-namespace": ns,
-            "pool": f"{self.fs_type}-pool",
+            "pool": f"{fs_type}-pool",
         }
 
-        update_storage_params(self.name, self.manifests.config, parameters)
+        self.update_params(parameters)
 
         return StorageClass.from_dict(
             dict(
@@ -108,6 +108,9 @@ class CephStorageClass(Addition):
 class ProvisionerAdjustments(Patch):
     """Update RBD provisioner."""
 
+    PROVISIONER_NAME = "csi-rbdplugin-provisioner"
+    PLUGIN_NAME = "csi-rbdplugin"
+
     def tolerations(self) -> List[CephToleration]:
         cfg = self.manifests.config.get("ceph-rbd-tolerations") or ""
         return CephToleration.from_space_separated(cfg)
@@ -118,7 +121,7 @@ class ProvisionerAdjustments(Patch):
         if (
             obj.kind == "Deployment"
             and obj.metadata
-            and obj.metadata.name == "csi-rbdplugin-provisioner"
+            and obj.metadata.name == self.PROVISIONER_NAME
         ):
             obj.spec.replicas = replica = self.manifests.config.get("provisioner-replicas")
             log.info(f"Updating deployment replicas to {replica}")
@@ -131,7 +134,7 @@ class ProvisionerAdjustments(Patch):
             )
             log.info(f"Updating deployment hostNetwork to {host_network}")
 
-        if obj.kind == "DaemonSet" and obj.metadata and obj.metadata.name == "csi-rbdplugin":
+        if obj.kind == "DaemonSet" and obj.metadata and obj.metadata.name == self.PLUGIN_NAME:
             obj.spec.template.spec.tolerations = tolerations
             log.info("Updating daemonset tolerations to operator=Exists")
 
@@ -160,8 +163,8 @@ class RBDManifests(SafeManifest):
                 ManifestLabelExcluder(self),
                 ConfigRegistry(self),
                 ProvisionerAdjustments(self),
-                CephStorageClass(self, "xfs"),  # creates ceph-xfs
-                CephStorageClass(self, "ext4"),  # creates ceph-ext4
+                CephStorageClass(self, "ceph-xfs"),  # creates ceph-xfs
+                CephStorageClass(self, "ceph-ext4"),  # creates ceph-ext4
                 RbacAdjustments(self),
                 AdjustNamespace(self),
                 ConfigureLivenessPrometheus(
@@ -213,4 +216,10 @@ class RBDManifests(SafeManifest):
         except ValueError as err:
             return f"Cannot adjust CephRBD Pods: {err}"
 
+        for storage_class in self.manipulations:
+            if isinstance(storage_class, CephStorageClass):
+                try:
+                    storage_class.evaluate()
+                except ValueError as err:
+                    return f"RBD manifests failed to create storage classes: {err}"
         return None

--- a/tests/functional/overlay.yaml
+++ b/tests/functional/overlay.yaml
@@ -38,6 +38,7 @@ applications:
     options:
       provisioner-replicas: 1
       namespace: {{ namespace }}
+      ceph-rbac-name-formatter: '{name}-formatter'
   ceph-csi-alt:
     # This is an alternative ceph-csi charm that is used to test
     # the ability to deploy multiple ceph-csi charms in the same
@@ -46,6 +47,10 @@ applications:
     options:
       provisioner-replicas: 1
       namespace: {{ namespace }}
+      # Intentionally matches the other ceph-csi charm's name
+      # in order to create a conflict and test the ability to
+      # detect the conflict.
+      ceph-rbac-name-formatter: '{name}-formatter'
 relations:
 - [ceph-osd,     ceph-mon]
 - [ceph-fs,      ceph-mon]

--- a/tests/functional/test_ceph_csi.py
+++ b/tests/functional/test_ceph_csi.py
@@ -116,7 +116,7 @@ async def test_rbac_name_formatter(kube_config: Path, ops_test):
     # Check that the ceph-csi cluster roles are using the correct name formatter
     assert len(cluster_roles) == 2
     for role in cluster_roles:
-        assert role.metadata.name.endswith("-ceph-csi")
+        assert role.metadata.name.endswith("-formatter")
 
 
 @pytest.mark.parametrize("storage_class", ["ceph-xfs", "ceph-ext4"])

--- a/tests/functional/test_ceph_csi.py
+++ b/tests/functional/test_ceph_csi.py
@@ -108,6 +108,17 @@ async def test_deployment_replicas(kube_config: Path, namespace: str, ops_test):
     assert rbdplugin.status.ready_replicas == len(k8s_workers.units)
 
 
+async def test_rbac_name_formatter(kube_config: Path, ops_test):
+    """Test that ceph-csi deployments use the correct rbac name formatter."""
+    config.load_kube_config(str(kube_config))
+    rbac_api = client.RbacAuthorizationV1Api()
+    cluster_roles = rbac_api.list_cluster_role(**RBD_LS).items
+    # Check that the ceph-csi cluster roles are using the correct name formatter
+    assert len(cluster_roles) == 2
+    for role in cluster_roles:
+        assert role.metadata.name.endswith("-ceph-csi")
+
+
 @pytest.mark.parametrize("storage_class", ["ceph-xfs", "ceph-ext4"])
 @pytest.mark.usefixtures("cleanup_k8s", "ops_test")
 async def test_storage_class(kube_config: Path, storage_class: str):

--- a/tests/unit/test_manifests_cephfs.py
+++ b/tests/unit/test_manifests_cephfs.py
@@ -170,6 +170,12 @@ def test_manifest_evaluation(caplog):
     assert "Skipping CephFS evaluation since it's disabled" in caplog.text
 
     charm.config = {"cephfs-enable": True}
+    assert (
+        manifests.evaluate()
+        == "CephFS manifests require the definition of 'ceph-rbac-name-formatter'"
+    )
+
+    charm.config["ceph-rbac-name-formatter"] = "{name}"
     assert manifests.evaluate() == "CephFS manifests require the definition of 'kubernetes_key'"
 
     charm.config["kubernetes_key"] = "123"

--- a/tests/unit/test_manifests_cephfs.py
+++ b/tests/unit/test_manifests_cephfs.py
@@ -9,6 +9,7 @@ from lightkube.resources.core_v1 import Secret
 from lightkube.resources.storage_v1 import StorageClass
 
 from manifests_cephfs import (
+    STORAGE_TYPE,
     CephFilesystem,
     CephFSManifests,
     CephStorageClass,
@@ -102,7 +103,7 @@ def test_ceph_storage_class_modelled(caplog):
     caplog.set_level(logging.INFO)
     manifest = mock.MagicMock()
     manifest.purging = False
-    csc = CephStorageClass(manifest)
+    csc = CephStorageClass(manifest, STORAGE_TYPE)
     alt_ns = "diff-ns"
 
     manifest.config = {
@@ -152,7 +153,7 @@ def test_ceph_storage_class_purging(caplog):
     caplog.set_level(logging.INFO)
     manifest = mock.MagicMock()
     manifest.purging = True
-    csc = CephStorageClass(manifest)
+    csc = CephStorageClass(manifest, STORAGE_TYPE)
 
     caplog.clear()
     expected = StorageClass(
@@ -195,7 +196,7 @@ def test_manifest_evaluation(caplog):
     )
 
     charm.config[CephStorageClass.FILESYSTEM_LISTING] = [TEST_CEPH_FS, TEST_CEPH_FS_ALT]
-    charm.config[sc_name_formatter_key] = CephStorageClass.STORAGE_TYPE
+    charm.config[sc_name_formatter_key] = STORAGE_TYPE
     assert manifests.evaluate() == err_formatter.format(
         sc_name_formatter_key + " does not generate unique names"
     )

--- a/tests/unit/test_manifests_cephfs.py
+++ b/tests/unit/test_manifests_cephfs.py
@@ -166,6 +166,7 @@ def test_manifest_evaluation(caplog):
     caplog.set_level(logging.INFO)
     charm = mock.MagicMock()
     manifests = CephFSManifests(charm)
+    sc_name_formatter_key = "cephfs-storage-class-name-formatter"
     assert manifests.evaluate() is None
     assert "Skipping CephFS evaluation since it's disabled" in caplog.text
 
@@ -190,16 +191,16 @@ def test_manifest_evaluation(caplog):
 
     charm.config[CephStorageClass.FILESYSTEM_LISTING] = [TEST_CEPH_FS]
     assert manifests.evaluate() == err_formatter.format(
-        "empty " + CephStorageClass.STORAGE_NAME_FORMATTER
+        "Missing storage class name " + sc_name_formatter_key
     )
 
     charm.config[CephStorageClass.FILESYSTEM_LISTING] = [TEST_CEPH_FS, TEST_CEPH_FS_ALT]
-    charm.config[CephStorageClass.STORAGE_NAME_FORMATTER] = CephStorageClass.STORAGE_NAME
+    charm.config[sc_name_formatter_key] = CephStorageClass.STORAGE_TYPE
     assert manifests.evaluate() == err_formatter.format(
-        CephStorageClass.STORAGE_NAME_FORMATTER + " does not generate unique names"
+        sc_name_formatter_key + " does not generate unique names"
     )
 
-    charm.config[CephStorageClass.STORAGE_NAME_FORMATTER] = "cephfs-{name}"
+    charm.config[sc_name_formatter_key] = "cephfs-{name}"
     assert manifests.evaluate() is None
 
     charm.config["cephfs-tolerations"] = "key=value,Foo"

--- a/tests/unit/test_manifests_rbd.py
+++ b/tests/unit/test_manifests_rbd.py
@@ -90,9 +90,15 @@ def test_manifest_evaluation(caplog):
     caplog.set_level(logging.INFO)
     charm = mock.MagicMock()
     manifests = RBDManifests(charm)
+    assert (
+        manifests.evaluate()
+        == "RBD manifests require the definition of 'ceph-rbac-name-formatter'"
+    )
+    charm.config = {"user": "cephx", "ceph-rbac-name-formatter": "{name}", "kubernetes_key": "123"}
+
     assert manifests.evaluate() == "RBD manifests require the definition of 'fsid'"
 
-    charm.config = {"user": "cephx", "fsid": "cluster", "kubernetes_key": "123"}
+    charm.config["fsid"] = "cluster"
     assert manifests.evaluate() is None
 
     charm.config["ceph-rbd-tolerations"] = "key=value,Foo"


### PR DESCRIPTION
Creates a formatter to prevent conflicts in names of non-namespaced objects in ClusterRole and ClusterRoleBindings


In order to deploy N ceph-csi charm applications into a model, we need to prepare the Kubernetes resources to have different names so they do not collide with one another.  While the charm can detect collisions, it can't work around them.  

This change allows some "non-namespaced" resources in the cluster to support a format-able name -- specifically the RBAC controls.  I'd be willing to discuss a better name for the charm config. 

the following may not be the clearest name:
```
ceph-rbac-name-formatter
```


There are really on a few Kubernetes resources that collide (because they aren't namespace scoped resources)
* `ClusterRole`
* `ClusterRoleBinding`
* `StorageClass`

The storage-classes have been resolved with their own formatters, so all that remains is supporting a rename of `ClusterRole` and `ClusterRoleBinding`. 
