### PR TITLE
When listing cephfs storage-classes, handle exceptions

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -406,8 +406,8 @@ class CephCsiCharm(ops.CharmBase):
         self.check_ceph_client()
         self.configure_ceph_cli()
         self.enforce_cephfs_enabled()
-        self.prevent_collisions(event)
         hash = self.evaluate_manifests()
+        self.prevent_collisions(event)
         self.install_manifests(config_hash=hash)
         self._update_status()
 

--- a/src/manifests_cephfs.py
+++ b/src/manifests_cephfs.py
@@ -189,11 +189,10 @@ class CephStorageClass(Addition):
             # which will look up all storage classes installed by this app/manifest
             return [StorageClass.from_dict(dict(metadata={}, provisioner=self.PROVISIONER))]
 
-        empty = []
         if not self.manifests.config.get("enabled"):
             # If cephfs is not enabled, we cannot add any storage classes
             log.info("Skipping CephFS storage class creation since it's disabled")
-            return empty
+            return []
 
         try:
             parameter_list = self.parameter_list()
@@ -201,7 +200,7 @@ class CephStorageClass(Addition):
             # If we cannot generate the parameter list, we cannot add
             # any storage classes
             log.error("Failed to list storage classes to add: %s", err)
-            return empty
+            return []
 
         return [self.create(class_param) for class_param in parameter_list]
 

--- a/src/manifests_cephfs.py
+++ b/src/manifests_cephfs.py
@@ -125,15 +125,22 @@ class CephStorageClass(Addition):
         )
 
     def parameter_list(self) -> List[CephStorageClassParameters]:
-        """Accumulate names and settings of the storage classes."""
-        enabled = self.manifests.config.get("enabled")
+        """Accumulate names and settings of the storage classes.
+
+        This can be a difficult problem to resolve the actual names
+        of the storage classes this method creates when not all the data
+        is available from the ceph cluster.
+
+        For example, the fs_data not being available from the cluster
+        means we cannot determine the data pools and cannot format a
+        name for the storage class for that pool.
+
+        In some event we cannot generate the parameter_list, this method
+        will raise a ValueError exception indicated the value missing.
+        """
         fsid = self.manifests.config.get("fsid")
         fs_data: List[CephFilesystem] = self.manifests.config.get(self.FILESYSTEM_LISTING) or []
         formatter = str(self.manifests.config.get(self.STORAGE_NAME_FORMATTER) or "")
-
-        if not enabled:
-            log.info("Ignore CephFS Storage Class")
-            return []
 
         if not fsid:
             log.error("CephFS is missing a filesystem: 'fsid'")
@@ -174,13 +181,29 @@ class CephStorageClass(Addition):
         return sc_names
 
     def __call__(self) -> List[AnyResource]:
-        """Craft the storage class object."""
+        """Craft the storage class objects."""
+
         if cast(SafeManifest, self.manifests).purging:
             # If we are purging, we may not be able to create any storage classes
             # Just return a fake storage class to satisfy delete_manifests method
             # which will look up all storage classes installed by this app/manifest
             return [StorageClass.from_dict(dict(metadata={}, provisioner=self.PROVISIONER))]
-        return [self.create(class_param) for class_param in self.parameter_list()]
+
+        empty = []
+        if not self.manifests.config.get("enabled"):
+            # If cephfs is not enabled, we cannot add any storage classes
+            log.info("Skipping CephFS storage class creation since it's disabled")
+            return empty
+
+        try:
+            parameter_list = self.parameter_list()
+        except ValueError as err:
+            # If we cannot generate the parameter list, we cannot add
+            # any storage classes
+            log.error("Failed to list storage classes to add: %s", err)
+            return empty
+
+        return [self.create(class_param) for class_param in parameter_list]
 
 
 class ProvisionerAdjustments(Patch):
@@ -296,7 +319,7 @@ class CephFSManifests(SafeManifest):
 
         config["namespace"] = self.charm.stored.namespace
         config["release"] = config.pop("release", None)
-        config["enabled"] = self.purging or config.get("cephfs-enable", None)
+        config["enabled"] = config.get("cephfs-enable", None)
         return config
 
     def evaluate(self) -> Optional[str]:

--- a/tests/unit/test_manifests_cephfs.py
+++ b/tests/unit/test_manifests_cephfs.py
@@ -106,8 +106,6 @@ def test_ceph_storage_class_modelled(caplog):
     alt_ns = "diff-ns"
 
     manifest.config = {
-        "enabled": True,
-        "fsid": "abcd",
         "fs_list": [TEST_CEPH_FS_ALT],
         "namespace": alt_ns,
         "default-storage": TEST_CEPH_FS_ALT.name,
@@ -115,6 +113,15 @@ def test_ceph_storage_class_modelled(caplog):
         "cephfs-storage-class-name-formatter": "{name}",
     }
 
+    assert csc() == []
+    assert "Skipping CephFS storage class creation since it's disabled" in caplog.text
+
+    manifest.config["enabled"] = True
+    caplog.clear()
+    assert csc() == []
+    assert "CephFS is missing a filesystem: 'fsid'" in caplog.text
+
+    manifest.config["fsid"] = "abcd"
     caplog.clear()
     expected = StorageClass(
         metadata=ObjectMeta(


### PR DESCRIPTION
fix: Prevent charm errors when ceph-client relations are setup

### Overview
Introduced in #35 , the cephfs storage classes class `parameter_list` raises `ValueError` when there is not enough information to build a list of storage classes.  There are situations in normal operation of the charm (`update-status` or charm actions) when this isn't during a `purging` operation.  In those situations, the best the manifest Manipulator can do is return an empty list. 