### PR TITLE
test: 2 Ceph clusters to ensure both are read/writable

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -81,13 +81,13 @@ config:
           - {namespace}        - the charm configured namespace
 
         Example:
-          juju config ceph-csi csidriver-name-formatter="{name}.{app}"
+          juju config ceph-csi csidriver-name-formatter="{app}.{name}"
 
         The default is to use the built-in storage classname
 
         NOTE: Can only be specified on deployment since some
-        attributes of kubernetes resources are non-modifiable.
-        The admin is responsible for creating the namespace.
+        attributes of kubernetes resources cannot be modified
+        once installed.
       type: string
 
     cephfs-storage-class-name-formatter:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -68,6 +68,28 @@ config:
       description: "Whether or not csi-*plugin-provisioner deployments use host-networking"
       type: boolean
 
+    csidriver-name-formatter:
+      default: "{name}"
+      description: |
+        Formatter for the 2 CSIDrivers managed by this charm:
+          - rbd.csi.ceph.com
+          - cephfs.csi.ceph.com
+
+        The formatter is a string that can contain the following placeholders:
+          - {name}             - original name from the manifest
+          - {app}              - the name of the juju application
+          - {namespace}        - the charm configured namespace
+
+        Example:
+          juju config ceph-csi csidriver-name-formatter="{name}.{app}"
+
+        The default is to use the built-in storage classname
+
+        NOTE: Can only be specified on deployment since some
+        attributes of kubernetes resources are non-modifiable.
+        The admin is responsible for creating the namespace.
+      type: string
+
     cephfs-storage-class-name-formatter:
       default: "cephfs"
       description: |
@@ -81,7 +103,7 @@ config:
           - {pool-id}          - the id   of the data-pool
 
         Example:
-          juju config ceph-csi cephfs-storage-class-name-formatter="{cluster}-{namespace}-{storageclass}"
+          juju config ceph-csi cephfs-storage-class-name-formatter="cephfs-{namespace}-{pool}"
 
         The default is to use the storage class name
       type: string
@@ -151,7 +173,7 @@ config:
           - {namespace}        - the charm configured namespace
 
         Example:
-          juju config ceph-csi ceph-xfs-storage-class-name-formatter="{cluster}-{namespace}-{storageclass}"
+          juju config ceph-csi ceph-xfs-storage-class-name-formatter="ceph-xfs-{app}"
 
         The default is to use the storage class name
       type: string
@@ -179,7 +201,7 @@ config:
           - {namespace}        - the charm configured namespace
 
         Example:
-          juju config ceph-csi ceph-ext4-storage-class-name-formatter="{cluster}-{namespace}-{storageclass}"
+          juju config ceph-csi ceph-ext4-storage-class-name-formatter="ceph-ext4-{app}"
 
         The default is to use the storage class name
       type: string

--- a/src/manifests_base.py
+++ b/src/manifests_base.py
@@ -1,13 +1,13 @@
 import logging
 import pickle
+from functools import cached_property
 from hashlib import md5
-from typing import Any, Dict, Generator, List, Optional
+from typing import Any, Dict, Generator, List, Optional, Tuple, cast
 
 from lightkube.codecs import AnyResource
 from lightkube.core.resource import NamespacedResource
 from lightkube.models.core_v1 import Toleration
-from ops.manifests import Addition, ManifestLabel, Manifests, Patch
-from ops.manifests.literals import APP_LABEL
+from ops.manifests import Addition, Manifests, Patch
 
 log = logging.getLogger(__name__)
 
@@ -18,6 +18,13 @@ class SafeManifest(Manifests):
     def hash(self) -> int:
         """Calculate a hash of the current configuration."""
         return int(md5(pickle.dumps(self.config)).hexdigest(), 16)
+
+    @property
+    def csidriver(self) -> "CSIDriverAdjustments":
+        for manipulation in self.manipulations:
+            if isinstance(manipulation, CSIDriverAdjustments):
+                return manipulation
+        raise ValueError("CSIDriverAdjustments not found")
 
     @property
     def config(self) -> Dict[str, Any]:
@@ -34,16 +41,6 @@ class AdjustNamespace(Patch):
         if isinstance(obj, NamespacedResource) and obj.metadata:
             ns = self.manifests.config["namespace"]
             obj.metadata.namespace = ns
-
-
-class ManifestLabelExcluder(ManifestLabel):
-    """Exclude applying labels to CSIDriver."""
-
-    def __call__(self, obj: AnyResource) -> None:
-        super().__call__(obj)
-        if obj.kind == "CSIDriver" and obj.metadata and obj.metadata.labels:
-            # Remove the app label from the CSIDriver to disassociate it from the application
-            obj.metadata.labels.pop(APP_LABEL, None)
 
 
 class RbacAdjustments(Patch):
@@ -251,3 +248,94 @@ class CephToleration(Toleration):
             return [cls._from_string(toleration) for toleration in tolerations.split()]
         except ValueError as e:
             raise ValueError(f"Invalid tolerations: {e}") from e
+
+
+class ProvisionerAdjustments(Patch):
+    """Update provisioner manifest objects."""
+
+    PROVISIONER_NAME: str
+    PLUGIN_NAME: str
+
+    def tolerations(self) -> Tuple[List[CephToleration], bool]:
+        return [], False
+
+    def adjust_container_specs(self, obj: AnyResource) -> None:
+        csidriver = cast(SafeManifest, self.manifests).csidriver
+        original_dn, updated_dn = csidriver.default_name, csidriver.formatted
+        kubelet_dir = self.manifests.config.get("kubelet_dir", "/var/lib/kubelet")
+
+        for c in obj.spec.template.spec.containers:
+            for idx in range(len(c.args)):
+                if original_dn in c.args[idx]:
+                    c.args[idx] = c.args[idx].replace(original_dn, updated_dn)
+                if "/var/lib/kubelet" in c.args[idx]:
+                    c.args[idx] = c.args[idx].replace("/var/lib/kubelet", kubelet_dir)
+            for m in c.volumeMounts:
+                m.mountPath = m.mountPath.replace("/var/lib/kubelet", kubelet_dir)
+        for v in obj.spec.template.spec.volumes:
+            if v.hostPath:
+                v.hostPath.path = v.hostPath.path.replace("/var/lib/kubelet", kubelet_dir)
+                v.hostPath.path = v.hostPath.path.replace(original_dn, updated_dn)
+
+    def __call__(self, obj: AnyResource) -> None:
+        """Use the provisioner-replicas and enable-host-networking to update obj."""
+        tolerations, legacy = self.tolerations()
+
+        if (
+            obj.kind == "Deployment"
+            and obj.metadata
+            and obj.metadata.name == self.PROVISIONER_NAME
+        ):
+            obj.spec.replicas = replica = self.manifests.config.get("provisioner-replicas")
+            log.info(f"Updating deployment replicas to {replica}")
+
+            obj.spec.template.spec.tolerations = tolerations
+            log.info("Updating deployment tolerations")
+
+            obj.spec.template.spec.hostNetwork = host_network = self.manifests.config.get(
+                "enable-host-networking"
+            )
+            log.info(f"Updating deployment hostNetwork to {host_network}")
+
+            log.info("Updating deployment specs")
+            self.adjust_container_specs(obj)
+
+        if obj.kind == "DaemonSet" and obj.metadata and obj.metadata.name == self.PLUGIN_NAME:
+            log.info("Updating daemonset tolerations")
+            obj.spec.template.spec.tolerations = (
+                tolerations if not legacy else [CephToleration(operator="Exists")]
+            )
+
+            log.info("Updating daemonset specs")
+            self.adjust_container_specs(obj)
+
+
+class CSIDriverAdjustments(Patch):
+    """Update CSI driver."""
+
+    NAME_FORMATTER = "csidriver-name-formatter"
+    REQUIRED_CONFIG = {NAME_FORMATTER}
+
+    def __init__(self, manifests: Manifests, default_name: str):
+        super().__init__(manifests)
+        self.default_name = default_name
+
+    @cached_property
+    def formatted(self) -> str:
+        """Rename the object."""
+        formatter = self.manifests.config[self.NAME_FORMATTER]
+        fmt_context = {
+            "name": self.default_name,
+            "app": self.manifests.model.app.name,
+            "namespace": self.manifests.config["namespace"],
+        }
+        return formatter.format(**fmt_context)
+
+    def __call__(self, obj: AnyResource) -> None:
+        """Format the name for the CSIDriver and and update obj."""
+        if not obj.metadata or not obj.metadata.name:
+            log.error("Object is missing metadata or name. %s", obj)
+            return
+
+        if obj.kind == "CSIDriver":
+            obj.metadata.name = self.formatted

--- a/src/manifests_base.py
+++ b/src/manifests_base.py
@@ -266,7 +266,7 @@ class ProvisionerAdjustments(Patch):
 
         for c in obj.spec.template.spec.containers:
             for idx in range(len(c.args)):
-                if original_dn in c.args[idx]:
+                if original_dn in c.args[idx] and updated_dn not in c.args[idx]:
                     c.args[idx] = c.args[idx].replace(original_dn, updated_dn)
                 if "/var/lib/kubelet" in c.args[idx]:
                     c.args[idx] = c.args[idx].replace("/var/lib/kubelet", kubelet_dir)

--- a/src/manifests_cephfs.py
+++ b/src/manifests_cephfs.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, cast
 from lightkube.codecs import AnyResource
 from lightkube.resources.core_v1 import Secret
 from lightkube.resources.storage_v1 import StorageClass
-from ops.manifests import Addition, ConfigRegistry
+from ops.manifests import Addition, ConfigRegistry, ManifestLabel
 from ops.manifests.manipulations import Subtraction
 
 from manifests_base import (
@@ -252,6 +252,7 @@ class CephFSManifests(SafeManifest):
                 ConfigureLivenessPrometheus(
                     self, "Service", "csi-metrics-cephfsplugin", "cephfsplugin"
                 ),
+                ManifestLabel(self),
             ],
         )
         self.charm = charm

--- a/src/manifests_rbd.py
+++ b/src/manifests_rbd.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, cast
 from lightkube.codecs import AnyResource
 from lightkube.resources.core_v1 import Secret
 from lightkube.resources.storage_v1 import StorageClass
-from ops.manifests import Addition, ConfigRegistry
+from ops.manifests import Addition, ConfigRegistry, ManifestLabel
 
 from manifests_base import (
     AdjustNamespace,
@@ -134,8 +134,8 @@ class RBDManifests(SafeManifest):
                 CephStorageClass(self, "ceph-xfs"),  # creates ceph-xfs
                 CephStorageClass(self, "ceph-ext4"),  # creates ceph-ext4
                 RbacAdjustments(self),
-                AdjustNamespace(self),
                 CSIDriverAdjustments(self, self.DRIVER_NAME),
+                AdjustNamespace(self),
                 ConfigureLivenessPrometheus(
                     self, "Deployment", "csi-rbdplugin-provisioner", "rbdplugin-provisioner"
                 ),
@@ -144,6 +144,7 @@ class RBDManifests(SafeManifest):
                 ),
                 ConfigureLivenessPrometheus(self, "DaemonSet", "csi-rbdplugin", "rbdplugin"),
                 ConfigureLivenessPrometheus(self, "Service", "csi-metrics-rbdplugin", "rbdplugin"),
+                ManifestLabel(self),
             ],
         )
         self.charm = charm

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.14.0"
+      version = ">= 0.14.0, < 1.0.0"
     }
   }
 }

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -28,7 +28,7 @@ async def kube_config(ops_test: OpsTest) -> AsyncGenerator[Path, None]:
 
     Config file is fetched from kubernetes-control-plane unit and stored in the temporary file.
     """
-    k_c_p = ops_test.model.applications["kubernetes-control-plane"]
+    k_c_p = ops_test.model.applications["k8s"]
     (leader,) = [u for u in k_c_p.units if (await u.is_leader_from_status())]
     action = await leader.run_action("get-kubeconfig")
     action = await action.wait()
@@ -41,7 +41,7 @@ async def kube_config(ops_test: OpsTest) -> AsyncGenerator[Path, None]:
     if not success:
         logging.error(f"status: {action.status}")
         logging.error(f"results:\n{yaml.safe_dump(action.results, indent=2)}")
-        pytest.fail("Failed to copy kubeconfig from kubernetes-control-plane")
+        pytest.fail("Failed to copy kubeconfig from k8s")
 
     kubeconfig_path = ops_test.tmp_path / "kubeconfig"
     with kubeconfig_path.open("w") as f:

--- a/tests/functional/overlay.yaml
+++ b/tests/functional/overlay.yaml
@@ -9,7 +9,8 @@ applications:
   k8s:
     num_units: 1
     expose: true
-    local-storage-enabled: false
+    options:
+      local-storage-enabled: false
   k8s-worker:
     num_units: 1
     expose: true
@@ -43,6 +44,7 @@ applications:
       provisioner-replicas: 1
       namespace: {{ namespace }}
       ceph-rbac-name-formatter: '{name}-formatter'
+      release: {{ release }}
 
   # Secondary Ceph Cluster
   ceph-fs-alt:
@@ -73,9 +75,10 @@ applications:
     # model.  It's used in test_duplicate_ceph_csi
     charm: {{ charm }}
     options:
+      release: {{ release }}
       provisioner-replicas: 1
       namespace: {{ namespace }}
-      csidriver-name-formatter: '{name}.alt'
+      csidriver-name-formatter: 'alt.{name}'
       # Intentionally matches the other ceph-csi charm's name
       # in order to create a conflict and test the ability to
       # detect the conflict.

--- a/tests/functional/overlay.yaml
+++ b/tests/functional/overlay.yaml
@@ -1,33 +1,36 @@
 description: Overlay for attaching current charm
+series: jammy
 applications:
   {% if https_proxy %}
   containerd:
     options:
       https_proxy: {{ https_proxy }}
   {% endif %}
-  kubernetes-control-plane:
+  k8s:
+    num_units: 1
     expose: true
-    options:
-      allow-privileged: "true"
-  kubernetes-worker:
+  k8s-worker:
+    num_units: 1
     expose: true
+
+  # Primary Ceph Cluster
   ceph-fs:
     charm: ceph-fs
     channel: "quincy/stable"
     num_units: 1
-    constraints: "cores=2 mem=4G root-disk=16G"
+    constraints: "cores=2 mem=4G root-disk=4G"
   ceph-mon:
     charm: ceph-mon
     channel: "quincy/stable"
     num_units: 1
-    constraints: "cores=2 mem=4G root-disk=16G"
+    constraints: "cores=2 mem=4G root-disk=4G"
     options:
       monitor-count: '1'
   ceph-osd:
     charm: ceph-osd
     channel: "quincy/stable"
     num_units: 2
-    constraints: "cores=2 mem=4G root-disk=16G"
+    constraints: "cores=2 mem=4G root-disk=4G"
     options:
       osd-devices: /srv/osd
     storage:
@@ -39,6 +42,30 @@ applications:
       provisioner-replicas: 1
       namespace: {{ namespace }}
       ceph-rbac-name-formatter: '{name}-formatter'
+
+  # Secondary Ceph Cluster
+  ceph-fs-alt:
+    charm: ceph-fs
+    channel: "quincy/stable"
+    num_units: 1
+    constraints: "cores=2 mem=4G root-disk=4G"
+  ceph-mon-alt:
+    charm: ceph-mon
+    channel: "quincy/stable"
+    num_units: 1
+    constraints: "cores=2 mem=4G root-disk=4G"
+    options:
+      monitor-count: '1'
+  ceph-osd-alt:
+    charm: ceph-osd
+    channel: "quincy/stable"
+    num_units: 2
+    constraints: "cores=2 mem=4G root-disk=4G"
+    options:
+      osd-devices: /srv/osd
+    storage:
+      osd-devices: 1G,2
+      osd-journals: 1G,1
   ceph-csi-alt:
     # This is an alternative ceph-csi charm that is used to test
     # the ability to deploy multiple ceph-csi charms in the same
@@ -47,6 +74,7 @@ applications:
     options:
       provisioner-replicas: 1
       namespace: {{ namespace }}
+      csidriver-name-formatter: '{name}.alt'
       # Intentionally matches the other ceph-csi charm's name
       # in order to create a conflict and test the ability to
       # detect the conflict.
@@ -55,5 +83,9 @@ relations:
 - [ceph-osd,     ceph-mon]
 - [ceph-fs,      ceph-mon]
 - [ceph-csi,     ceph-mon:client]
-- [ceph-csi-alt, ceph-mon:client]
-- [ceph-csi,     kubernetes-control-plane]
+
+- [ceph-osd-alt, ceph-mon-alt]
+- [ceph-fs-alt,  ceph-mon-alt]
+- [ceph-csi-alt, ceph-mon-alt:client]
+
+- [ceph-csi:kubernetes-info,     k8s]

--- a/tests/functional/overlay.yaml
+++ b/tests/functional/overlay.yaml
@@ -9,6 +9,7 @@ applications:
   k8s:
     num_units: 1
     expose: true
+    local-storage-enabled: false
   k8s-worker:
     num_units: 1
     expose: true

--- a/tests/functional/test_ceph_csi.py
+++ b/tests/functional/test_ceph_csi.py
@@ -50,7 +50,7 @@ async def test_build_and_deploy(ops_test: OpsTest, namespace: str):
     if proxy_settings:
         bundle_vars["https_proxy"] = proxy_settings
 
-    overlays = [ops_test.Bundle("kubernetes-core", channel="stable"), TEST_OVERLAY]
+    overlays = [ops_test.Bundle("canonical-kubernetes", channel="latest/edge"), TEST_OVERLAY]
 
     bundle, *overlays = await ops_test.async_render_bundles(*overlays, **bundle_vars)
 
@@ -101,7 +101,7 @@ async def test_deployment_replicas(kube_config: Path, namespace: str, ops_test):
     config.load_kube_config(str(kube_config))
     apps_api = client.AppsV1Api()
     (rbdplugin,) = apps_api.list_namespaced_deployment(namespace, **RBD_LS).items
-    k8s_workers = ops_test.model.applications["kubernetes-worker"]
+    k8s_workers = ops_test.model.applications["k8s-worker"]
     assert rbdplugin.status.replicas == 1  # from the test overlay.yaml
     # Due to anti-affinity rules on the control-plane, the ready replicas
     # are limited to the number of worker nodes, of which there are 1
@@ -154,21 +154,26 @@ async def run_test_storage_class(kube_config: Path, storage_class: str):
     )
     writing_pod_name = writing_pod["metadata"]["name"]
 
-    logger.info("Creating PersistentVolumeClaim %s", storage["metadata"]["name"])
-    utils.create_from_dict(k8s_api_client, storage)
+    try:
+        logger.info("Creating PersistentVolumeClaim %s", storage["metadata"]["name"])
+        utils.create_from_dict(k8s_api_client, storage)
 
-    logger.info("Creating Pod %s", writing_pod_name)
-    utils.create_from_dict(k8s_api_client, writing_pod)
-    wait_for_pod(core_api, writing_pod_name, namespace, target_state=SUCCESS_POD_STATE)
+        logger.info("Creating Pod %s", writing_pod_name)
+        utils.create_from_dict(k8s_api_client, writing_pod)
+        wait_for_pod(core_api, writing_pod_name, namespace, target_state=SUCCESS_POD_STATE)
 
-    logger.info("Creating Pod %s", reading_pod_name)
-    utils.create_from_dict(k8s_api_client, reading_pod)
-    wait_for_pod(core_api, reading_pod_name, namespace, target_state=SUCCESS_POD_STATE)
+        logger.info("Creating Pod %s", reading_pod_name)
+        utils.create_from_dict(k8s_api_client, reading_pod)
+        wait_for_pod(core_api, reading_pod_name, namespace, target_state=SUCCESS_POD_STATE)
 
-    pod_log = core_api.read_namespaced_pod_log(reading_pod_name, namespace)
-    assert test_payload in pod_log, "Pod {} failed to read data written by pod {}".format(
-        reading_pod_name, writing_pod_name
-    )
+        pod_log = core_api.read_namespaced_pod_log(reading_pod_name, namespace)
+        assert test_payload in pod_log, "Pod {} failed to read data written by pod {}".format(
+            reading_pod_name, writing_pod_name
+        )
+    finally:
+        core_api.delete_namespaced_pod(reading_pod_name, namespace)
+        core_api.delete_namespaced_pod(writing_pod_name, namespace)
+        core_api.delete_namespaced_persistent_volume_claim(storage["metadata"]["name"], namespace)
 
 
 async def test_update_default_storage_class(kube_config: Path, ops_test: OpsTest):
@@ -257,7 +262,7 @@ async def test_cephfs(kube_config: Path, namespace: str, ops_test):
     """Test that ceph-csi deployments include cephfs."""
     config.load_kube_config(str(kube_config))
     apps_api = client.AppsV1Api()
-    k8s_workers = ops_test.model.applications["kubernetes-worker"]
+    k8s_workers = ops_test.model.applications["k8s-worker"]
 
     (cephfsplugin,) = apps_api.list_namespaced_deployment(namespace, **CEPHFS_LS).items
     assert cephfsplugin.status.ready_replicas == len(k8s_workers.units)
@@ -270,11 +275,11 @@ async def test_conflicting_ceph_csi(ops_test: OpsTest):
     app = ops_test.model.applications[CEPH_CSI_ALT]
     expected_msg = "resource collisions (action: list-resources)"
     try:
-        await app.relate("kubernetes", "kubernetes-control-plane")
+        await app.relate("kubernetes-info", "k8s")
         await ops_test.model.wait_for_idle(apps=[CEPH_CSI_ALT], status="blocked", timeout=5 * 60)
-        assert expected_msg in app.units[0].workload_status_message
+        assert any(expected_msg in u.workload_status_message for u in app.units)
     finally:
-        await app.destroy_relation("kubernetes", "kubernetes-control-plane:juju-info")
+        await app.destroy_relation("kubernetes-info", "k8s")
         await ops_test.model.wait_for_idle(
             apps=[CEPH_CSI_ALT], wait_for_exact_units=0, timeout=5 * 60
         )
@@ -307,10 +312,15 @@ async def test_duplicate_ceph_csi(ops_test: OpsTest, namespace: str, kube_config
     )
 
     try:
-        await app.relate("kubernetes", "kubernetes-control-plane")
+        await app.relate("kubernetes-info", "k8s")
         await ops_test.model.wait_for_idle(apps=[CEPH_CSI_ALT], status="active", timeout=5 * 60)
+
+        await run_test_storage_class(kube_config, "ceph-xfs")
+        await run_test_storage_class(kube_config, f"ceph-xfs-{alt_namespace}")
+        await run_test_storage_class(kube_config, "ceph-ext4")
+        await run_test_storage_class(kube_config, f"ceph-ext4-{alt_namespace}")
     finally:
-        await app.destroy_relation("kubernetes", "kubernetes-control-plane:juju-info")
+        await app.destroy_relation("kubernetes-info", "k8s")
         await ops_test.model.wait_for_idle(
             apps=[CEPH_CSI_ALT], wait_for_exact_units=0, timeout=5 * 60
         )

--- a/tests/functional/test_ceph_csi.py
+++ b/tests/functional/test_ceph_csi.py
@@ -18,6 +18,7 @@ from utils import render_j2_template, wait_for_pod
 
 logger = logging.getLogger(__name__)
 
+LATEST_RELEASE = ""  # ops.manifest will load the latest release when unspecified
 TEST_PATH = Path(__file__).parent
 TEMPLATE_DIR = TEST_PATH / "templates"
 TEST_OVERLAY = TEST_PATH / "overlay.yaml"
@@ -45,7 +46,11 @@ async def test_build_and_deploy(ops_test: OpsTest, namespace: str):
         logger.info("Building ceph-csi charm.")
         charm = await ops_test.build_charm(".")
 
-    bundle_vars = {"charm": charm.resolve(), "namespace": namespace}
+    bundle_vars = {
+        "charm": charm.resolve(),
+        "namespace": namespace,
+        "release": environ.get("TEST_RELEASE", LATEST_RELEASE),
+    }
     proxy_settings = environ.get("TEST_HTTPS_PROXY")
     if proxy_settings:
         bundle_vars["https_proxy"] = proxy_settings


### PR DESCRIPTION
### Overview
Ensure that Canonical K8s (or charmed kubernetes) can operate with N Ceph Clusters without conflict

### Details
* introduction of charm config `csidriver-name-formatter` to differentiate CSI drivers managed by each `ceph-csi` application
* tests that Canonical Kubernetes can support multiple ceph clusters via multiple ceph-csi charms. 
* Each ceph-csi charm relates to a separate ceph cluster
* Accommodations at the kubelet plugin level are made to ensure that no collisions between the csi_drivers exist on the nodes where the csi drivers operate.   (rbd.csi.ceph.com vs rdb.csi.ceph.com.alt)
