### PR TITLE
feat: Drop focal support from ceph-csi

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,6 +20,6 @@ jobs:
     name: Lint Unit
     uses: charmed-kubernetes/workflows/.github/workflows/lint-unit.yaml@main
     with:
-      python: "['3.8', '3.9', '3.10', '3.11']"
+      python: "['3.10', '3.12']"
     needs:
       - call-inclusive-naming-check

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -29,15 +29,9 @@ parts:
 bases:
   - build-on:
     - name: "ubuntu"
-      channel: "20.04"
+      channel: "22.04"
       architectures: ["amd64"]
     run-on:
-    - name: "ubuntu"
-      channel: "20.04"
-      architectures:
-      - amd64
-      - s390x
-      - arm64
     - name: "ubuntu"
       channel: "22.04"
       architectures:


### PR DESCRIPTION
Applicable spec: KU-2847

### Overview

* Drops support for python 3.8 and focal as a part of the 1.33 release

### Rationale

In May 2025, Focal loses it's 5-year LTS status in favor of jammy and noble. 
