### PR TITLE
Refactor CLI calls and create cephfs volume subgroups

### DIFF
--- a/.github/workflows/vsphere-integration.yaml
+++ b/.github/workflows/vsphere-integration.yaml
@@ -11,11 +11,11 @@ jobs:
         uses: actions/checkout@v4
       - name: Read charmcraft version file
         id: charmcraft
-        run: echo "channel=$(cat .charmcraft-channel)" >> $GITHUB_OUTPUT        
+        run: echo "channel=$(cat .charmcraft-channel)" >> $GITHUB_OUTPUT
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: "3.10"
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -146,6 +146,15 @@ config:
         csi-cephfsplugin.
       type: string
 
+    cephfs-subvolumegroups:
+      default: "csi"
+      type: string
+      description: |
+        Subvolume groups to be ensured within the cephfs volume.
+        https://docs.ceph.com/en/reef/cephfs/fs-volumes/#fs-subvolume-groups
+
+        Declare subvolume groups separated by spaces.
+
     ceph-rbd-tolerations:
       default: ""
       description: |
@@ -350,7 +359,7 @@ actions:
         type: string
         default: ""
         description: |
-          Space separated list of kubernetes resource types to filter scrubbing   
+          Space separated list of kubernetes resource types to filter scrubbing
   sync-resources:
     description: |
       Add kubernetes resources which should be created by this charm which aren't
@@ -391,4 +400,3 @@ requires:
   kubernetes-info:
     interface: kubernetes-info
     scope: container
-

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -22,8 +22,6 @@ parts:
   charm:
     plugin: charm
     build-packages: [git]
-    charm-python-packages:
-      - setuptools  # for jinja2
     prime:
       - upstream/**
 bases:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -146,15 +146,6 @@ config:
         csi-cephfsplugin.
       type: string
 
-    cephfs-subvolumegroups:
-      default: "csi"
-      type: string
-      description: |
-        Subvolume groups to be ensured within the cephfs volume.
-        https://docs.ceph.com/en/reef/cephfs/fs-volumes/#fs-subvolume-groups
-
-        Declare subvolume groups separated by spaces.
-
     ceph-rbd-tolerations:
       default: ""
       description: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ interface_ceph_client @ git+https://github.com/openstack/charm-ops-interface-cep
 charms.reconciler == 0.0.1
 charms.contextual-status == 0.0.1
 charmhelpers == 1.2.1
-setuptools == 69.5.1
+setuptools == 79.0.1
 
 # require netifaces to prevent a dynamic apt install during interface_ceph_client -> charmhelpers import
 # https://github.com/juju/charm-helpers/blob/a72931f7324526e7f05221847437238517f38fa7/charmhelpers/contrib/network/ip.py#L37-L42

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ setuptools == 79.0.1
 
 # require netifaces to prevent a dynamic apt install during interface_ceph_client -> charmhelpers import
 # https://github.com/juju/charm-helpers/blob/a72931f7324526e7f05221847437238517f38fa7/charmhelpers/contrib/network/ip.py#L37-L42
-netifaces
+netifaces == 0.11.0

--- a/src/literals.py
+++ b/src/literals.py
@@ -1,0 +1,17 @@
+# Copyright 2025 Canonical
+# See LICENSE file for licensing details.
+
+# https://docs.ceph.com/en/reef/cephfs/fs-volumes/#fs-subvolume-groups
+CEPHFS_SUBVOLUMEGROUP = "csi"
+
+# Name of the relation from charmcraft.yaml
+CEPH_CLIENT_RELATION = "ceph-client"
+
+# List of required Ceph packages used by the charm
+CEPH_PACKAGES = ["ceph-common"]
+
+# List of required Ceph pools used by the charm
+REQUIRED_CEPH_POOLS = ["xfs-pool", "ext4-pool"]
+
+# Default Names where the CephFS CSI driver operates, override with config
+DEFAULT_NAMESPACE = "default"

--- a/src/manifests_config.py
+++ b/src/manifests_config.py
@@ -13,6 +13,7 @@ from lightkube.codecs import AnyResource
 from lightkube.resources.core_v1 import ConfigMap
 from ops.manifests import Addition, ManifestLabel
 
+import literals
 from manifests_base import AdjustNamespace, SafeManifest
 
 if TYPE_CHECKING:
@@ -115,8 +116,14 @@ class CephCsiConfig(Addition):
             return None
 
         log.info(f"Modelling configmap for {self.NAME}.")
-        config_json = [{"clusterID": fsid, "monitors": mon_hosts}]
-        data = {"config.json": json.dumps(config_json)}
+        config_json = [
+            {
+                "clusterID": fsid,
+                "monitors": mon_hosts,
+                "CephFS": {"subvolumeGroup": literals.CEPHFS_SUBVOLUMEGROUP},
+            }
+        ]
+        data = {"config.json": json.dumps(config_json, sort_keys=True)}
         return ConfigMap.from_dict(dict(metadata=dict(name=self.NAME), data=data))
 
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,133 @@
+# Copyright 2025 Canonical
+# See LICENSE file for licensing details.
+
+import configparser
+import json
+import logging
+import subprocess
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Protocol
+
+from manifests_cephfs import CephFilesystem
+
+CONFIG_DIR = Path("ceph-conf").resolve()
+CONFIG_PATH = CONFIG_DIR / "ceph.conf"
+log = logging.getLogger(__name__)
+
+
+class CharmLike(Protocol):
+    """Protocol for a charm-like object"""
+
+    @property
+    def app(self) -> Any: ...
+
+    @property
+    def auth(self) -> str | None: ...
+
+    @property
+    def key(self) -> str | None: ...
+
+    @property
+    def unit(self) -> Any: ...
+
+    @property
+    def mon_hosts(self) -> list[str]: ...
+
+
+def _keyring_path(user: str) -> Path:
+    """Return the path to the keyring file for a given user"""
+    return CONFIG_DIR / f"ceph.client.{user}.keyring"
+
+
+class CephCLI:
+    """Ceph CLI wrapper for configuration and command execution"""
+
+    def __init__(self, charm: CharmLike) -> None:
+        """Initialize the CephCLI with the charm instance"""
+        self._charm = charm
+
+    def configure(self) -> None:
+        """Create the ceph.conf and keyring files"""
+        CONFIG_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
+        self._write_config()
+        self._write_keyring()
+
+    def command(self, *args: str, timeout: int = 60) -> str:
+        """Run a command and return the output"""
+        user = self._charm.app.name
+        cmd = ["/usr/bin/ceph", "--conf", CONFIG_PATH.as_posix(), "--user", user, *args]
+        return subprocess.check_output(cmd, timeout=timeout).decode("UTF-8")
+
+    def command_json(self, *args: str, timeout: int = 60) -> Any:
+        """Run a command and return the JSON output"""
+        result = self.command("--format", "json", *args, timeout=timeout)
+        return json.loads(result)
+
+    def _write_config(self) -> None:
+        """Write Ceph CLI .conf file"""
+        config = configparser.ConfigParser()
+        unit_name = self._charm.unit.name.replace("/", "-")
+        config["global"] = {
+            "auth cluster required": self._charm.auth or "",
+            "auth service required": self._charm.auth or "",
+            "auth client required": self._charm.auth or "",
+            "keyring": f"{CONFIG_DIR}/$cluster.$name.keyring",
+            "mon host": " ".join(self._charm.mon_hosts),
+            "log to syslog": "true",
+            "err to syslog": "true",
+            "clog to syslog": "true",
+            "mon cluster log to syslog": "true",
+            "debug mon": "1/5",
+            "debug osd": "1/5",
+        }
+        config["client"] = {"log file": f"/var/log/ceph/{unit_name}.log"}
+
+        with CONFIG_PATH.open("w") as fp:
+            config.write(fp)
+
+    def _write_keyring(self) -> None:
+        """Write Ceph CLI keyring file"""
+        config = configparser.ConfigParser()
+        user = self._charm.app.name
+        config[f"client.{user}"] = {"key": self._charm.key or ""}
+        with _keyring_path(user).open("w") as fp:
+            config.write(fp)
+
+
+@lru_cache(maxsize=None)
+def fsid(cli: CephCLI) -> str:
+    """Get the Ceph FSID (cluster ID)"""
+    try:
+        return cli.command("fsid").strip()
+    except subprocess.SubprocessError:
+        log.error("get_ceph_fsid: Failed to get CephFS ID, reporting as empty string")
+        return ""
+
+
+@lru_cache(maxsize=None)
+def ls_ceph_fs(cli: CephCLI) -> list[CephFilesystem]:
+    """Get a list of CephFS names and list of associated pools."""
+    try:
+        data = cli.command_json("fs", "ls")
+    except (subprocess.SubprocessError, ValueError) as e:
+        log.error("ls_ceph_fs: Failed to find CephFS name, reporting as None, error: %s", e)
+        data = []
+
+    return [CephFilesystem(**fs) for fs in data]
+
+
+def ensure_subvolumegroups(cli: CephCLI, volume: str, groups: set[str]) -> None:
+    """Get a list of CephFS subvolumegroups."""
+    try:
+        data = cli.command_json("fs", "subvolumegroup", "ls", volume)
+        current = set(group["name"] for group in data)
+        missing = groups - current
+        for group in missing:
+            cli.command("fs", "subvolumegroup", "create", volume, group)
+    except (subprocess.SubprocessError, ValueError) as e:
+        log.error(
+            "ensure_subvolumegroups (%s): Failed to ensure CephFS subvolumegroups, error: %s",
+            volume,
+            e,
+        )

--- a/tests/functional/overlay.yaml
+++ b/tests/functional/overlay.yaml
@@ -44,7 +44,7 @@ applications:
       provisioner-replicas: 1
       namespace: {{ namespace }}
       ceph-rbac-name-formatter: '{name}-formatter'
-      release: {{ release }}
+      release: "{{ release }}"
 
   # Secondary Ceph Cluster
   ceph-fs-alt:
@@ -75,7 +75,7 @@ applications:
     # model.  It's used in test_duplicate_ceph_csi
     charm: {{ charm }}
     options:
-      release: {{ release }}
+      release: "{{ release }}"
       provisioner-replicas: 1
       namespace: {{ namespace }}
       csidriver-name-formatter: 'alt.{name}'

--- a/tests/functional/test_ceph_csi.py
+++ b/tests/functional/test_ceph_csi.py
@@ -14,6 +14,7 @@ import pytest
 import pytest_asyncio
 from kubernetes import client, config, utils
 from pytest_operator.plugin import OpsTest
+
 from utils import render_j2_template, wait_for_pod
 
 logger = logging.getLogger(__name__)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -28,3 +28,17 @@ def api_error_klass():
 def lk_charm_client():
     with mock.patch("charm.Client", autospec=True) as mock_lightkube:
         yield mock_lightkube.return_value
+
+
+@pytest.fixture(autouse=True)
+def ceph_conf_directory(monkeypatch, tmp_path):
+    path = tmp_path / "ceph-conf"
+    monkeypatch.setattr("utils.CONFIG_DIR", path)
+    yield path
+
+
+@pytest.fixture(autouse=True)
+def ceph_conf_file(monkeypatch, ceph_conf_directory):
+    path = ceph_conf_directory / "ceph.conf"
+    monkeypatch.setattr("utils.CONFIG_PATH", path)
+    yield path

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -5,9 +5,7 @@
 """Collection of tests related to src/charm.py"""
 
 import contextlib
-import json
 import unittest.mock as mock
-from subprocess import SubprocessError
 
 import charms.operator_libs_linux.v0.apt as apt
 import ops
@@ -17,7 +15,7 @@ from lightkube.resources.storage_v1 import StorageClass
 from ops.manifests import HashableResource, ManifestClientError, ManifestLabel, ResourceAnalysis
 from ops.testing import Harness
 
-from charm import CephCsiCharm, CephFilesystem
+from charm import CephCsiCharm
 from manifests_config import EncryptConfig
 
 
@@ -31,13 +29,6 @@ def harness():
 
 
 @pytest.fixture(autouse=True)
-def ceph_conf_directory(tmp_path):
-    with mock.patch("charm.ceph_config_dir") as mock_path:
-        mock_path.return_value = tmp_path / "ceph-conf"
-        yield mock_path
-
-
-@pytest.fixture(autouse=True)
 def mock_apt():
     with mock.patch(
         "charms.operator_libs_linux.v0.apt.DebianPackage.from_system", autospec=True
@@ -45,68 +36,9 @@ def mock_apt():
         yield mock_apt
 
 
-@mock.patch("charm.CephCsiCharm.ceph_data", new_callable=mock.PropertyMock)
-@mock.patch("charm.ceph_config_file")
-def test_write_ceph_cli_config(ceph_config_file, ceph_data, harness, ceph_conf_directory):
-    """Test writing of Ceph CLI config"""
-    harness.begin()
-    ceph_data.return_value = {"auth": "cephx", "mon_hosts": ["10.0.0.1", "10.0.0.2"]}
-    harness.charm.write_ceph_cli_config()
-    path = ceph_config_file.return_value
-    path.open.assert_called_once_with("w")
-    unit_name = harness.charm.unit.name.replace("/", "-")
-    with path.open() as fp:
-        lines = [
-            "[global]",
-            "auth cluster required = cephx",
-            "auth service required = cephx",
-            "auth client required = cephx",
-            f"keyring = {ceph_conf_directory.return_value}/$cluster.$name.keyring",
-            "mon host = 10.0.0.1 10.0.0.2",
-            "log to syslog = true",
-            "err to syslog = true",
-            "clog to syslog = true",
-            "mon cluster log to syslog = true",
-            "debug mon = 1/5",
-            "debug osd = 1/5",
-            "",
-            "[client]",
-            f"log file = /var/log/ceph/{unit_name}.log",
-            "",
-        ]
-        fp.write.assert_has_calls([mock.call(_l + "\n") for _l in lines])
-
-
-@mock.patch("charm.CephCsiCharm.ceph_data", new_callable=mock.PropertyMock)
-@mock.patch("charm.ceph_keyring_file")
-def test_write_ceph_cli_keyring(ceph_keyring_file, ceph_data, harness):
-    """Test writing of Ceph CLI keyring file"""
-    harness.begin()
-    ceph_data.return_value = {"key": "12345"}
-    harness.charm.write_ceph_cli_keyring()
-    ceph_keyring_file.return_value.open.assert_called_once_with("w")
-    with ceph_keyring_file.return_value.open() as fp:
-        lines = ["[client.ceph-csi]", "key = 12345", ""]
-        fp.write.assert_has_calls([mock.call(_l + "\n") for _l in lines])
-
-
-@mock.patch("charm.CephCsiCharm.write_ceph_cli_config")
-@mock.patch("charm.CephCsiCharm.write_ceph_cli_keyring")
-@mock.patch("charm.ceph_config_dir")
-def test_configure_ceph_cli(ceph_config_dir, keyring, config, harness):
-    """Test configuration of Ceph CLI"""
-    harness.begin()
-    harness.charm.configure_ceph_cli()
-    ceph_config_dir.return_value.mkdir.assert_called_once_with(
-        mode=0o700, parents=True, exist_ok=True
-    )
-    config.assert_called_once()
-    keyring.assert_called_once()
-
-
 @mock.patch("subprocess.check_output")
 @mock.patch("charm.CephCsiCharm.ceph_data", new_callable=mock.PropertyMock)
-def test_ceph_context_getter(ceph_data, check_output, harness, ceph_conf_directory):
+def test_ceph_context_getter(ceph_data, check_output, harness, ceph_conf_file):
     """Test that ceph_context property returns properly formatted data."""
     fsid = "12345"
     key = "secret_key"
@@ -134,12 +66,12 @@ def test_ceph_context_getter(ceph_data, check_output, harness, ceph_conf_directo
     }
 
     assert harness.charm.ceph_context == expected_context
-    conf = (ceph_conf_directory() / "ceph.conf").absolute().as_posix()
+    conf = ceph_conf_file.absolute().as_posix()
     check_output.assert_any_call(
         ["/usr/bin/ceph", "--conf", conf, "--user", "ceph-csi", "fsid"], timeout=60
     )
     check_output.assert_any_call(
-        ["/usr/bin/ceph", "--conf", conf, "--user", "ceph-csi", "fs", "ls", "-f", "json"],
+        ["/usr/bin/ceph", "--conf", conf, "--user", "ceph-csi", "--format", "json", "fs", "ls"],
         timeout=60,
     )
 
@@ -160,8 +92,7 @@ def mocked_handlers():
         "check_kube_config",
         "check_namespace",
         "check_ceph_client",
-        "configure_ceph_cli",
-        "enforce_cephfs_enabled",
+        "_cephfs_configure",
         "evaluate_manifests",
         "prevent_collisions",
         "install_manifests",
@@ -184,7 +115,7 @@ def test_set_leader(harness):
     harness.charm.reconciler.stored.reconciled = False  # Pretended to not be reconciled
     with mocked_handlers() as handlers:
         handlers["_destroying"].return_value = False
-        handlers["enforce_cephfs_enabled"].return_value = False
+        handlers["_cephfs_configure"].return_value = False
         harness.set_leader(True)
     assert harness.charm.unit.status.name == "active"
     assert harness.charm.unit.status.message == "Ready"
@@ -255,7 +186,6 @@ def test_check_namespace(harness, lk_charm_client):
     assert harness.charm.unit.status.name == "active"
 
 
-@mock.patch("charm.CephCsiCharm.configure_ceph_cli", mock.MagicMock())
 def test_check_ceph_client(harness):
     """Test that check_ceph_client sets expected unit states."""
 
@@ -413,7 +343,6 @@ def test_cleanup(_purge_manifest, harness, caplog):
     _purge_manifest.assert_called()
 
 
-@mock.patch("charm.CephCsiCharm.configure_ceph_cli", mock.MagicMock())
 def test_action_list_versions(harness):
     harness.begin()
 
@@ -427,9 +356,8 @@ def test_action_list_versions(harness):
     mock_event.set_results.assert_called_once_with(expected_results)
 
 
-@mock.patch("charm.CephCsiCharm.configure_ceph_cli", mock.MagicMock())
-@mock.patch("charm.CephCsiCharm.get_ceph_fsid", mock.MagicMock(return_value="12345"))
-@mock.patch("charm.CephCsiCharm.get_ceph_fs_list", mock.MagicMock(return_value={}))
+@mock.patch("utils.fsid", mock.MagicMock(return_value="12345"))
+@mock.patch("utils.ls_ceph_fs", mock.MagicMock(return_value=[]))
 def test_action_manifest_resources(harness, lk_client, api_error_klass):
     harness.begin_with_initial_hooks()
     not_found = api_error_klass()
@@ -469,9 +397,8 @@ def test_action_manifest_resources(harness, lk_client, api_error_klass):
     assert action.results == expected_results
 
 
-@mock.patch("charm.CephCsiCharm.configure_ceph_cli", mock.MagicMock())
-@mock.patch("charm.CephCsiCharm.get_ceph_fsid", mock.MagicMock(return_value="12345"))
-@mock.patch("charm.CephCsiCharm.get_ceph_fs_list", mock.MagicMock(return_value={}))
+@mock.patch("utils.fsid", mock.MagicMock(return_value="12345"))
+@mock.patch("utils.ls_ceph_fs", mock.MagicMock(return_value=[]))
 def test_action_sync_resources_install_failure(harness, lk_client, api_error_klass):
     harness.begin_with_initial_hooks()
     not_found = api_error_klass()
@@ -517,36 +444,6 @@ def test_action_delete_storage_class(harness, lk_client):
     lk_client.delete.assert_called_once_with(StorageClass, name="cephfs")
 
 
-@mock.patch("charm.CephCsiCharm.ceph_cli", mock.MagicMock(side_effect=SubprocessError))
-def test_failed_cli_fsid(harness):
-    harness.begin()
-    assert harness.charm.get_ceph_fsid() == ""
-
-
-@pytest.mark.parametrize("failure", [SubprocessError, lambda *_: "invalid"])
-def test_failed_cli_fs_list(harness, failure):
-    harness.begin()
-    with mock.patch("charm.CephCsiCharm.ceph_cli", side_effect=failure):
-        assert harness.charm.get_ceph_fs_list() == []
-
-
-def test_cli_fsdata(request, harness):
-    harness.begin()
-    fs_name = request.node.name
-    fs_data = [
-        {
-            "name": f"{fs_name}-alt",
-            "metadata_pool": f"{fs_name}-alt_metadata",
-            "metadata_pool_id": 5,
-            "data_pool_ids": [4],
-            "data_pools": [f"{fs_name}-alt_data"],
-        }
-    ]
-    pools = json.dumps(fs_data)
-    with mock.patch("charm.CephCsiCharm.ceph_cli", return_value=pools):
-        assert harness.charm.get_ceph_fs_list() == [CephFilesystem(**fs) for fs in fs_data]
-
-
 def test_kubelet_dir(harness):
     harness.begin()
     data = {"kubelet-root-dir": "/var/snap/k8s/common/var/lib/kubelet"}
@@ -562,7 +459,7 @@ def test_kubelet_dir(harness):
 def test_enforce_cephfs_enabled(mock_purge, harness):
     harness.begin()
 
-    with reconcile_this(harness, lambda _: harness.charm.enforce_cephfs_enabled()):
+    with reconcile_this(harness, lambda _: harness.charm._cephfs_configure()):
         # disabled on leader, purge
         harness.disable_hooks()
         harness.set_leader(True)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,128 @@
+import json
+import subprocess
+import unittest.mock as mock
+
+import utils
+from manifests_cephfs import CephFilesystem
+
+
+def test_write_ceph_cli_config(ceph_conf_directory):
+    """Test writing of Ceph CLI config"""
+    charm = mock.MagicMock()
+    charm.auth = "cephx"
+    charm.mon_hosts = ["10.0.0.1", "10.0.0.2"]
+    charm.key = "12345"
+    charm.app.name = "ceph-csi"
+    charm.unit.name = "ceph-csi/0"
+
+    cli = utils.CephCLI(charm)
+    cli.configure()
+
+    unit_name = charm.unit.name.replace("/", "-")
+    lines = [
+        "[global]",
+        "auth cluster required = cephx",
+        "auth service required = cephx",
+        "auth client required = cephx",
+        f"keyring = {ceph_conf_directory}/$cluster.$name.keyring",
+        "mon host = 10.0.0.1 10.0.0.2",
+        "log to syslog = true",
+        "err to syslog = true",
+        "clog to syslog = true",
+        "mon cluster log to syslog = true",
+        "debug mon = 1/5",
+        "debug osd = 1/5",
+        "",
+        "[client]",
+        f"log file = /var/log/ceph/{unit_name}.log",
+        "",
+    ]
+    assert utils.CONFIG_PATH.read_text() == "\n".join(lines) + "\n"
+
+    path = utils._keyring_path(charm.app.name)
+    lines = ["[client.ceph-csi]", "key = 12345", ""]
+    assert path.read_text() == "\n".join(lines) + "\n"
+
+
+def test_failed_cli_fsid():
+    charm = mock.MagicMock()
+    cli = utils.CephCLI(charm)
+
+    with mock.patch("utils.CephCLI.command", side_effect=subprocess.SubprocessError) as cmd:
+        utils.fsid.cache_clear()
+        assert utils.fsid(cli) == ""
+    cmd.assert_called_once_with("fsid")
+
+    with mock.patch("utils.CephCLI.command", mock.MagicMock(return_value="invalid")) as cmd:
+        utils.fsid.cache_clear()
+        assert utils.fsid(cli) == "invalid"
+    cmd.assert_called_once_with("fsid")
+
+
+def test_failed_cli_fs_list():
+    charm = mock.MagicMock()
+    cli = utils.CephCLI(charm)
+
+    with mock.patch("utils.CephCLI.command", side_effect=subprocess.SubprocessError) as cmd:
+        utils.ls_ceph_fs.cache_clear()
+        assert utils.ls_ceph_fs(cli) == []
+    cmd.assert_called_once_with("--format", "json", "fs", "ls", timeout=60)
+
+    with mock.patch("utils.CephCLI.command", mock.MagicMock(return_value="invalid")) as cmd:
+        utils.ls_ceph_fs.cache_clear()
+        assert utils.ls_ceph_fs(cli) == []
+    cmd.assert_called_once_with("--format", "json", "fs", "ls", timeout=60)
+
+
+def test_cli_fsdata(request):
+    charm = mock.MagicMock()
+    cli = utils.CephCLI(charm)
+
+    fs_name = request.node.name
+    fs_data = [
+        {
+            "name": f"{fs_name}-alt",
+            "metadata_pool": f"{fs_name}-alt_metadata",
+            "metadata_pool_id": 5,
+            "data_pool_ids": [4],
+            "data_pools": [f"{fs_name}-alt_data"],
+        }
+    ]
+    pools = json.dumps(fs_data)
+    with mock.patch("utils.CephCLI.command", return_value=pools):
+        assert utils.ls_ceph_fs(cli) == [CephFilesystem(**fs) for fs in fs_data]
+
+
+def test_cli_ensure_subvolumegroups():
+    charm = mock.MagicMock()
+    cli = utils.CephCLI(charm)
+
+    with mock.patch("utils.CephCLI.command_json", return_value=[]) as json:
+        with mock.patch("utils.CephCLI.command", return_value=[]) as cmd:
+            utils.ensure_subvolumegroups(cli, "ceph-fs", {"group1", "group2"})
+
+    json.assert_called_once_with("fs", "subvolumegroup", "ls", "ceph-fs")
+    cmd.assert_any_call("fs", "subvolumegroup", "create", "ceph-fs", "group1")
+    cmd.assert_any_call("fs", "subvolumegroup", "create", "ceph-fs", "group2")
+
+
+def test_failed_cli_ensure_subvolumegroups():
+    charm = mock.MagicMock()
+    cli = utils.CephCLI(charm)
+
+    with mock.patch("utils.CephCLI.command", return_value=[]) as cmd:
+        with mock.patch(
+            "utils.CephCLI.command_json", side_effect=subprocess.SubprocessError
+        ) as json:
+            utils.ensure_subvolumegroups(cli, "ceph-fs", {"group1", "group2"})
+
+        json.assert_called_once_with("fs", "subvolumegroup", "ls", "ceph-fs")
+        cmd.assert_not_called()
+        cmd.reset_mock()
+
+        with mock.patch("utils.CephCLI.command_json", side_effect=ValueError) as json:
+            utils.ensure_subvolumegroups(cli, "ceph-fs", {"group1", "group2"})
+
+        json.assert_called_once_with("fs", "subvolumegroup", "ls", "ceph-fs")
+        cmd.assert_not_called()
+        cmd.reset_mock()

--- a/tox.ini
+++ b/tox.ini
@@ -43,8 +43,12 @@ setenv =
     PYTHONPATH={toxinidir}/tests/functional/
 passenv =
     TEST_HTTPS_PROXY
-deps = -r{toxinidir}/requirements-test.txt
-commands = 
+deps =
+    jinja2
+    kubernetes
+    pytest-operator
+    pyyaml
+commands =
     pytest --log-cli-level=INFO \
            {posargs} \
            {toxinidir}/tests/functional/


### PR DESCRIPTION
Addresses [LP#2109660](https://bugs.launchpad.net/charm-ceph-csi/+bug/2109660)

The main thrust is to add a new cli command that's run by this charm to create a cephfs subvolume group since this is not auto created anymore by the ceph-csi operator.

## Mid-sized refactor
* creating a literals module
* creating a utils module to handle all the CLI interaction
* pinning `setuptools == 79.0.1`

