### PR TITLE
Implement RBD Disabling

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -144,6 +144,13 @@ config:
         csi-cephfsplugin.
       type: string
 
+    ceph-rbd-enable:
+      default: true
+      description: |
+        Whether or not ceph-rbd manifests should be installed.
+        This controls both storage classes xfs and ext4
+      type: boolean
+
     ceph-rbd-tolerations:
       default: ""
       description: |

--- a/src/charm.py
+++ b/src/charm.py
@@ -107,8 +107,11 @@ class CephCsiCharm(ops.CharmBase):
             event.set_results({"result": f"Successfully deleted StorageClass/{storage_class}"})
 
     def _update_status(self) -> None:
-        unready = self.collector.unready
-        if unready:
+        if not (self.config["ceph-rbd-enable"] or self.config["cephfs-enable"]):
+            msg = "Neither ceph-rbd nor cephfs is enabled."
+            status.add(ops.BlockedStatus(msg))
+            raise status.ReconcilerError(msg)
+        elif unready := self.collector.unready:
             status.add(ops.WaitingStatus(", ".join(unready)))
             raise status.ReconcilerError("Waiting for deployment")
         elif self.stored.namespace != self._configured_ns:
@@ -235,21 +238,20 @@ class CephCsiCharm(ops.CharmBase):
                 raise status.ReconcilerError("Waiting for Kubernetes API")
 
     @status.on_error(ops.WaitingStatus("Waiting for kubeconfig"))
-    def _ceph_rbd_enabled(self) -> bool:
+    def _ceph_rbd_enabled(self) -> None:
         """Determine if CephRBD should be enabled or disabled."""
 
-        if enabled := bool(self.config["ceph-rbd-enable"]):
+        if self.config["ceph-rbd-enable"]:
             self.unit.status = ops.MaintenanceStatus("Enabling CephRBD")
         else:
             self.unit.status = ops.MaintenanceStatus("Disabling CephRBD")
             if self.unit.is_leader():
                 self._purge_manifest_by_name("rbd")
-        return enabled
 
     @status.on_error(ops.WaitingStatus("Waiting for kubeconfig"))
-    def _cephfs_enabled(self) -> bool:
+    def _cephfs_enabled(self) -> None:
         """Determine if CephFS should be enabled or disabled."""
-        if enabled := bool(self.config["cephfs-enable"]):
+        if self.config["cephfs-enable"]:
             self.unit.status = ops.MaintenanceStatus("Enabling CephFS")
             groups = {literals.CEPHFS_SUBVOLUMEGROUP}
             for volume in utils.ls_ceph_fs(self.cli):
@@ -258,7 +260,6 @@ class CephCsiCharm(ops.CharmBase):
             self.unit.status = ops.MaintenanceStatus("Disabling CephFS")
             if self.unit.is_leader():
                 self._purge_manifest_by_name("cephfs")
-        return enabled
 
     def prevent_collisions(self, event: ops.EventBase) -> None:
         """Prevent manifest collisions."""
@@ -355,15 +356,12 @@ class CephCsiCharm(ops.CharmBase):
         self.check_namespace()
         self.check_ceph_client()
         self.cli.configure()
-        if self._cephfs_enabled() or self._ceph_rbd_enabled():
-            hash = self.evaluate_manifests()
-            self.prevent_collisions(event)
-            self.install_manifests(config_hash=hash)
-            self._update_status()
-        else:
-            msg = "Neither ceph-rbd nor cephfs is enabled."
-            status.add(ops.BlockedStatus(msg))
-            raise status.ReconcilerError(msg)
+        self._ceph_rbd_enabled()
+        self._cephfs_enabled()
+        hash = self.evaluate_manifests()
+        self.prevent_collisions(event)
+        self.install_manifests(config_hash=hash)
+        self._update_status()
 
     def request_ceph_pools(self) -> None:
         """Request creation of Ceph pools from the ceph-client relation"""

--- a/src/manifests_cephfs.py
+++ b/src/manifests_cephfs.py
@@ -240,7 +240,7 @@ class CephFSManifests(SafeManifest):
             if value == "" or value is None:
                 del config[key]
 
-        config["release"] = config.pop("release", None)
+        config["release"] = config.get("release", None)
         config["enabled"] = config.get("cephfs-enable", None)
         config["namespace"] = self.charm.stored.namespace
         config["csidriver-name-formatter"] = self.charm.stored.drivername

--- a/src/manifests_cephfs.py
+++ b/src/manifests_cephfs.py
@@ -7,10 +7,8 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, cast
 
 from lightkube.codecs import AnyResource
-from lightkube.resources.core_v1 import Secret
 from lightkube.resources.storage_v1 import StorageClass
-from ops.manifests import Addition, ConfigRegistry, ManifestLabel
-from ops.manifests.manipulations import Subtraction
+from ops.manifests import ConfigRegistry, ManifestLabel
 
 from manifests_base import (
     AdjustNamespace,
@@ -19,8 +17,10 @@ from manifests_base import (
     CSIDriverAdjustments,
     ProvisionerAdjustments,
     RbacAdjustments,
+    RemoveResource,
     SafeManifest,
     StorageClassFactory,
+    StorageSecret,
 )
 
 if TYPE_CHECKING:
@@ -51,35 +51,14 @@ class CephStorageClassParameters:
     data_pool: str
 
 
-class StorageSecret(Addition):
+class CephFSSecret(StorageSecret):
     """Create secret for the deployment."""
 
-    SECRET_NAME = "csi-cephfs-secret"
-
+    NAME = "csi-cephfs-secret"
     REQUIRED_CONFIG = {
         "user": ["userID", "adminID"],
         "kubernetes_key": ["userKey", "adminKey"],
     }
-
-    def __call__(self) -> Optional[AnyResource]:
-        """Craft the secrets object for the deployment."""
-        if not self.manifests.config["enabled"]:
-            log.info("Ignore Cephfs Storage Secrets")
-            return None
-
-        secret_config = {}
-        for k, keys in self.REQUIRED_CONFIG.items():
-            for secret_key in keys:
-                if value := self.manifests.config.get(k):
-                    secret_config[secret_key] = value
-                else:
-                    log.error(f"Cephfs is missing required secret item: '{k}'")
-                    return None
-
-        log.info("Modelling secret data for cephfs storage.")
-        return Secret.from_dict(
-            dict(metadata=dict(name=self.SECRET_NAME), stringData=secret_config)
-        )
 
 
 class CephStorageClass(StorageClassFactory):
@@ -101,11 +80,11 @@ class CephStorageClass(StorageClassFactory):
         parameters = {
             "clusterID": param.cluster_id,
             "fsName": param.filesystem_name,
-            "csi.storage.k8s.io/controller-expand-secret-name": StorageSecret.SECRET_NAME,
+            "csi.storage.k8s.io/controller-expand-secret-name": CephFSSecret.NAME,
             "csi.storage.k8s.io/controller-expand-secret-namespace": ns,
-            "csi.storage.k8s.io/provisioner-secret-name": StorageSecret.SECRET_NAME,
+            "csi.storage.k8s.io/provisioner-secret-name": CephFSSecret.NAME,
             "csi.storage.k8s.io/provisioner-secret-namespace": ns,
-            "csi.storage.k8s.io/node-stage-secret-name": StorageSecret.SECRET_NAME,
+            "csi.storage.k8s.io/node-stage-secret-name": CephFSSecret.NAME,
             "csi.storage.k8s.io/node-stage-secret-namespace": ns,
             "pool": param.data_pool,
         }
@@ -187,7 +166,6 @@ class CephStorageClass(StorageClassFactory):
             return [StorageClass.from_dict(dict(metadata={}, provisioner=driver_name))]
 
         if not self.manifests.config.get("enabled"):
-            # If cephfs is not enabled, we cannot add any storage classes
             log.info("Skipping CephFS storage class creation since it's disabled")
             return []
 
@@ -215,14 +193,6 @@ class FSProvAdjustments(ProvisionerAdjustments):
         return CephToleration.from_space_separated(cfg), False
 
 
-class RemoveCephFS(Subtraction):
-    """Remove all Cephfs resources when disabled."""
-
-    def __call__(self, _obj: AnyResource) -> bool:
-        """Remove this obj if cephfs is not enabled."""
-        return not self.manifests.config["enabled"]
-
-
 class CephFSManifests(SafeManifest):
     """Deployment Specific details for the cephfs.csi.ceph.com driver."""
 
@@ -234,13 +204,13 @@ class CephFSManifests(SafeManifest):
             charm.model,
             "upstream/cephfs",
             [
-                StorageSecret(self),
+                CephFSSecret(self),
                 ConfigRegistry(self),
                 FSProvAdjustments(self),
                 CephStorageClass(self, STORAGE_TYPE),
                 CSIDriverAdjustments(self, self.DRIVER_NAME),
                 RbacAdjustments(self),
-                RemoveCephFS(self),
+                RemoveResource(self),
                 AdjustNamespace(self),
                 ConfigureLivenessPrometheus(
                     self, "Deployment", "csi-cephfsplugin-provisioner", "cephfsplugin-provisioner"
@@ -282,7 +252,7 @@ class CephFSManifests(SafeManifest):
             log.info("Skipping CephFS evaluation since it's disabled")
             return None
 
-        props = StorageSecret.REQUIRED_CONFIG.keys() | RbacAdjustments.REQUIRED_CONFIG
+        props = CephFSSecret.REQUIRED_CONFIG.keys() | RbacAdjustments.REQUIRED_CONFIG
         for prop in sorted(props):
             value = self.config.get(prop)
             if not value:

--- a/src/manifests_rbd.py
+++ b/src/manifests_rbd.py
@@ -162,6 +162,10 @@ class RBDManifests(SafeManifest):
 
     def evaluate(self) -> Optional[str]:
         """Determine if manifest_config can be applied to manifests."""
+        if not self.config.get("enabled"):
+            log.info("Skipping CephRBD evaluation since it's disabled")
+            return None
+
         props = (
             CephRBDSecret.REQUIRED_CONFIG.keys()
             | CephStorageClass.REQUIRED_CONFIG

--- a/src/manifests_rbd.py
+++ b/src/manifests_rbd.py
@@ -6,9 +6,8 @@ import logging
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, cast
 
 from lightkube.codecs import AnyResource
-from lightkube.resources.core_v1 import Secret
 from lightkube.resources.storage_v1 import StorageClass
-from ops.manifests import Addition, ConfigRegistry, ManifestLabel
+from ops.manifests import ConfigRegistry, ManifestLabel
 
 from manifests_base import (
     AdjustNamespace,
@@ -17,8 +16,10 @@ from manifests_base import (
     CSIDriverAdjustments,
     ProvisionerAdjustments,
     RbacAdjustments,
+    RemoveResource,
     SafeManifest,
     StorageClassFactory,
+    StorageSecret,
 )
 
 if TYPE_CHECKING:
@@ -27,30 +28,14 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
-class StorageSecret(Addition):
+class CephRBDSecret(StorageSecret):
     """Create secret for the deployment."""
 
-    SECRET_NAME = "csi-rbd-secret"
-
+    NAME = "csi-rbd-secret"
     REQUIRED_CONFIG = {
-        "user": "userID",
-        "kubernetes_key": "userKey",
+        "user": ["userID"],
+        "kubernetes_key": ["userKey"],
     }
-
-    def __call__(self) -> Optional[AnyResource]:
-        """Craft the secrets object for the deployment."""
-        secret_config = {}
-        for k, secret_key in self.REQUIRED_CONFIG.items():
-            if value := self.manifests.config.get(k):
-                secret_config[secret_key] = value
-            else:
-                log.error(f"RBD is missing required secret item: '{k}'")
-                return None
-
-        log.info("Modelling secret data for rbd storage.")
-        return Secret.from_dict(
-            dict(metadata=dict(name=self.SECRET_NAME), stringData=secret_config)
-        )
 
 
 class CephStorageClass(StorageClassFactory):
@@ -61,6 +46,7 @@ class CephStorageClass(StorageClassFactory):
     def __call__(self) -> Optional[AnyResource]:
         """Craft the storage class object."""
         driver_name = cast(SafeManifest, self.manifests).csidriver.formatted
+        fs_type = self._fs_type.split("-")[1]
 
         if cast(SafeManifest, self.manifests).purging:
             # If we are purging, we may not be able to create any storage classes
@@ -68,8 +54,13 @@ class CephStorageClass(StorageClassFactory):
             # which will look up all storage classes installed by this app/manifest
             return StorageClass.from_dict(dict(metadata={}, provisioner=driver_name))
 
+        if not self.manifests.config.get("enabled"):
+            log.info(
+                "Skipping Ceph %s storage class creation since it's disabled", fs_type.capitalize()
+            )
+            return None
+
         clusterID = self.manifests.config.get("fsid")
-        fs_type = self._fs_type.split("-")[1]
         if not clusterID:
             log.error(f"Ceph {fs_type.capitalize()} is missing required storage item: 'fsid'")
             return None
@@ -82,12 +73,12 @@ class CephStorageClass(StorageClassFactory):
         log.info(f"Modelling storage class {metadata['name']}")
         parameters = {
             "clusterID": clusterID,
-            "csi.storage.k8s.io/controller-expand-secret-name": StorageSecret.SECRET_NAME,
+            "csi.storage.k8s.io/controller-expand-secret-name": CephRBDSecret.NAME,
             "csi.storage.k8s.io/controller-expand-secret-namespace": ns,
             "csi.storage.k8s.io/fstype": fs_type,
-            "csi.storage.k8s.io/node-stage-secret-name": StorageSecret.SECRET_NAME,
+            "csi.storage.k8s.io/node-stage-secret-name": CephRBDSecret.NAME,
             "csi.storage.k8s.io/node-stage-secret-namespace": ns,
-            "csi.storage.k8s.io/provisioner-secret-name": StorageSecret.SECRET_NAME,
+            "csi.storage.k8s.io/provisioner-secret-name": CephRBDSecret.NAME,
             "csi.storage.k8s.io/provisioner-secret-namespace": ns,
             "pool": f"{fs_type}-pool",
         }
@@ -128,12 +119,13 @@ class RBDManifests(SafeManifest):
             charm.model,
             "upstream/rbd",
             [
-                StorageSecret(self),
+                CephRBDSecret(self),
                 ConfigRegistry(self),
                 RBDProvAdjustments(self),
                 CephStorageClass(self, "ceph-xfs"),  # creates ceph-xfs
                 CephStorageClass(self, "ceph-ext4"),  # creates ceph-ext4
                 RbacAdjustments(self),
+                RemoveResource(self),
                 CSIDriverAdjustments(self, self.DRIVER_NAME),
                 AdjustNamespace(self),
                 ConfigureLivenessPrometheus(
@@ -163,6 +155,7 @@ class RBDManifests(SafeManifest):
                 del config[key]
 
         config["release"] = config.get("release", None)
+        config["enabled"] = config.get("ceph-rbd-enable", None)
         config["namespace"] = self.charm.stored.namespace
         config["csidriver-name-formatter"] = self.charm.stored.drivername
         return config
@@ -170,7 +163,7 @@ class RBDManifests(SafeManifest):
     def evaluate(self) -> Optional[str]:
         """Determine if manifest_config can be applied to manifests."""
         props = (
-            StorageSecret.REQUIRED_CONFIG.keys()
+            CephRBDSecret.REQUIRED_CONFIG.keys()
             | CephStorageClass.REQUIRED_CONFIG
             | RbacAdjustments.REQUIRED_CONFIG
         )

--- a/tests/unit/test_manifests_cephfs.py
+++ b/tests/unit/test_manifests_cephfs.py
@@ -13,9 +13,9 @@ from manifests_cephfs import (
     STORAGE_TYPE,
     CephFilesystem,
     CephFSManifests,
+    CephFSSecret,
     CephStorageClass,
     FSProvAdjustments,
-    StorageSecret,
 )
 
 TEST_CEPH_FS = CephFilesystem(
@@ -44,25 +44,26 @@ plugin_path = current_path / (FSProvAdjustments.PLUGIN_NAME + ".yaml")
 def test_storage_secret_modelled(caplog):
     caplog.set_level(logging.INFO)
     manifest = mock.MagicMock()
-    ss = StorageSecret(manifest)
+    manifest.name = "cephfs"
+    ss = CephFSSecret(manifest)
     manifest.config = {"enabled": False}
     assert ss() is None
-    assert "Ignore Cephfs Storage Secret" in caplog.text
+    assert "Ignore Secret from " in caplog.text
 
     caplog.clear()
     manifest.config = {"enabled": True}
     assert ss() is None
-    assert "Cephfs is missing required secret item: 'user'" in caplog.text
+    assert "cephfs is missing required secret item: 'user'" in caplog.text
 
     caplog.clear()
     manifest.config = {"enabled": True, "user": "abcd"}
     assert ss() is None
-    assert "Cephfs is missing required secret item: 'kubernetes_key'" in caplog.text
+    assert "cephfs is missing required secret item: 'kubernetes_key'" in caplog.text
 
     caplog.clear()
     manifest.config = {"enabled": True, "user": "abcd", "kubernetes_key": "123"}
     expected = Secret(
-        metadata=ObjectMeta(name=StorageSecret.SECRET_NAME),
+        metadata=ObjectMeta(name=CephFSSecret.NAME),
         stringData={
             "userID": "abcd",
             "adminID": "abcd",
@@ -71,7 +72,7 @@ def test_storage_secret_modelled(caplog):
         },
     )
     assert ss() == expected
-    assert "Modelling secret data for cephfs storage." in caplog.text
+    assert "Modelling secret data for cephfs." in caplog.text
 
 
 def test_ceph_provisioner_adjustment_modelled(caplog):
@@ -140,11 +141,11 @@ def test_ceph_storage_class_modelled(caplog):
         provisioner=CephFSManifests.DRIVER_NAME,
         parameters={
             "clusterID": "abcd",
-            "csi.storage.k8s.io/controller-expand-secret-name": StorageSecret.SECRET_NAME,
+            "csi.storage.k8s.io/controller-expand-secret-name": CephFSSecret.NAME,
             "csi.storage.k8s.io/controller-expand-secret-namespace": alt_ns,
-            "csi.storage.k8s.io/provisioner-secret-name": StorageSecret.SECRET_NAME,
+            "csi.storage.k8s.io/provisioner-secret-name": CephFSSecret.NAME,
             "csi.storage.k8s.io/provisioner-secret-namespace": alt_ns,
-            "csi.storage.k8s.io/node-stage-secret-name": StorageSecret.SECRET_NAME,
+            "csi.storage.k8s.io/node-stage-secret-name": CephFSSecret.NAME,
             "csi.storage.k8s.io/node-stage-secret-namespace": alt_ns,
             "fsName": "ceph-fs-alt",
             "mounter": "fuse",

--- a/tests/unit/test_manifests_cephfs.py
+++ b/tests/unit/test_manifests_cephfs.py
@@ -45,8 +45,10 @@ def test_storage_secret_modelled(caplog):
     caplog.set_level(logging.INFO)
     manifest = mock.MagicMock()
     manifest.name = "cephfs"
-    ss = CephFSSecret(manifest)
+    manifest.purging = False
     manifest.config = {"enabled": False}
+
+    ss = CephFSSecret(manifest)
     assert ss() is None
     assert "Ignore Secret from " in caplog.text
 


### PR DESCRIPTION
Spec: KU161

### Overview
* Support disabling the ceph-rbd storage providers
* Blocks the charm in the event that neither ceph-rbd or cephfs are enabled
* Supports purging of ceph-rbd manifests when disabled

### Details
* Move the now more common Manifest modifiers to `manifest_base.py`
* Handle purging rbd if its disabled
* Handle blocked if both are disabled.