### PR TITLE
Test scheduled with latest/edge and latest/stable ceph-csi

### DIFF
--- a/.github/workflows/vsphere-integration.yaml
+++ b/.github/workflows/vsphere-integration.yaml
@@ -1,11 +1,37 @@
 name: Charmed Kubernetes VSphere Integration Tests
-on: [pull_request]
+on:
+  pull_request:
+  schedule:
+  - cron: "0 2 * * *"  # Run daily at 2 AM UTC
+
 
 jobs:
+  charm-source:
+    name: Ceph-CSI Source
+    runs-on: ubuntu-latest
+    outputs:
+      channel: ${{ steps.charm.outputs.channel }}
+    steps:
+      - name: Pull-Request charm channel
+        id: charm
+        run: |
+          if [ "${{ github.event_name }}" = "schedule" ]]; then
+            CHANNEL=$(jq -c -n '["latest/edge", "latest/stable"]')
+          else
+            CHANNEL=$(jq -c -n '[null]')
+          fi
+          echo "channel=${CHANNEL}" >> $GITHUB_OUTPUT
   integration-test:
     name: VSphere Integration Test
+    needs: charm-source
+    strategy:
+      matrix:
+        channel: ${{ fromJson(needs.charm-source.outputs.channel) }}
     runs-on: self-hosted
     timeout-minutes: 120
+    env:
+      # Set default values
+      EXTRA_ARGS: "--basetemp=/home/ubuntu/pytest"
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -27,8 +53,13 @@ jobs:
           bootstrap-options: "${{ secrets.JAMMY_BOOTSTRAP_OPTIONS }} --model-default datastore=vsanDatastore --model-default primary-network=VLAN_2763 --config caas-image-repo=rocks.canonical.com/cdk/jujusolutions"
           juju-channel: "3/stable"
 
+      - if: ${{ needs.charm-source.outputs.channel }}
+        name: Test from ceph-csi channel=${{ needs.charm-source.outputs.channel }}
+        run: |
+          echo "EXTRA_ARGS=${EXTRA_ARGS} --ceph-csi-channel=${{needs.charm-source.outputs.channel}}" >> $GITHUB_ENV
+
       - name: Run test
-        run: tox -e integration -- --basetemp=/home/ubuntu/pytest
+        run: tox -e integration -- ${EXTRA_ARGS}
 
       - name: Setup Debug Artifact Collection
         if: ${{ failure() }}

--- a/.github/workflows/vsphere-integration.yaml
+++ b/.github/workflows/vsphere-integration.yaml
@@ -3,6 +3,7 @@ on:
   pull_request:
   schedule:
   - cron: "0 2 * * *"  # Run daily at 2 AM UTC
+  - cron: "0 0 * * 0"  # Run weekly at midnight on Sundays
 
 
 jobs:
@@ -15,18 +16,24 @@ jobs:
       - name: Pull-Request charm channel
         id: charm
         run: |
-          if [ "${{ github.event_name }}" = "schedule" ]]; then
-            CHANNEL=$(jq -c -n '["latest/edge", "latest/stable"]')
-          else
-            CHANNEL=$(jq -c -n '[null]')
+          set -euo pipefail
+          CHANNEL=""
+          SCHEDULE="${{ github.event.schedule || '' }}"
+          if [ "${SCHEDULE}" = "0 2 * * *" ]; then
+            CHANNEL="latest/edge"
+            echo "Using ${CHANNEL} channel for daily schedule"
+          elif [ "${SCHEDULE}" = "0 0 * * 0" ]; then
+            CHANNEL="latest/stable"
+            echo "Using ${CHANNEL} channel for weekly schedule"
+          fi
+
+          if [ -z "${CHANNEL}" ]; then
+            echo "Using empty channel for pull request"
           fi
           echo "channel=${CHANNEL}" >> $GITHUB_OUTPUT
   integration-test:
     name: VSphere Integration Test
     needs: charm-source
-    strategy:
-      matrix:
-        channel: ${{ fromJson(needs.charm-source.outputs.channel) }}
     runs-on: self-hosted
     timeout-minutes: 120
     env:

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -16,6 +16,21 @@ from pytest_operator.plugin import OpsTest
 logger = logging.getLogger(__name__)
 
 
+def pytest_addoption(parser):
+    parser.addoption(
+        "--ceph-csi-channel",
+        action="store",
+        default=None,
+        help="Optional charm channel for ceph-csi deployment",
+    )
+
+
+@pytest.fixture(scope="session")
+def ceph_csi_channel(pytestconfig):
+    """Return the ceph-csi channel if specified."""
+    return pytestconfig.getoption("ceph_csi_channel")
+
+
 @pytest.fixture(scope="module")
 def namespace(ops_test) -> str:
     """Return namespace used for ceph-csi installment."""

--- a/tests/functional/overlay.yaml
+++ b/tests/functional/overlay.yaml
@@ -1,11 +1,6 @@
 description: Overlay for attaching current charm
 series: jammy
 applications:
-  {% if https_proxy %}
-  containerd:
-    options:
-      https_proxy: {{ https_proxy }}
-  {% endif %}
   k8s:
     num_units: 1
     expose: true
@@ -40,6 +35,7 @@ applications:
       osd-journals: 1G,1
   ceph-csi:
     charm: {{ charm }}
+    channel: {{ channel | default("null", true) }}
     options:
       provisioner-replicas: 1
       namespace: {{ namespace }}
@@ -74,6 +70,7 @@ applications:
     # the ability to deploy multiple ceph-csi charms in the same
     # model.  It's used in test_duplicate_ceph_csi
     charm: {{ charm }}
+    channel: {{ channel | default("null", true) }}
     options:
       release: "{{ release }}"
       provisioner-replicas: 1


### PR DESCRIPTION
### Overview
* Run the integration tests not just on PR, but also nightly with latest/edge and weekly with latest/stable charm

### Details
* All vsphere integration tests run based on the charm's `channel`
   * if the channel is `null`, it's a pull request and we should build the charm
   * if the channel is valid, use that as an extra arg in the test
* Adjust the overlay bundle to deploy either the `ceph-csi` from a channel, or deploy a local charm