### PR TITLE
Add `image-registry` configuration option (#31)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -74,6 +74,21 @@ options:
       https://github.com/ceph/ceph-csi/blob/devel/examples/rbd/storageclass.yaml
     type: string
 
+  image-registry:
+    type: string
+    default: "rocks.canonical.com:443/cdk"
+    description: |
+      Image registry for all Ceph CSI container images.
+
+      This value replaces the image registry in image URLs from the release
+      manifests. For example, an image URL like
+      `quay.io/cephcsi/cephcsi:v3.8.0` becomes
+      `rocks.canonical.com:443/cdk/cephcsi/cephcsi:v3.8.0` if set to
+      `rocks.canonical.com:443/cdk`.
+
+      Example:
+        juju config ceph-csi image-registry="rocks.canonical.com:443/cdk"
+
   metrics-port-cephfsplugin:
     default: -1
     description: |

--- a/src/manifests_cephfs.py
+++ b/src/manifests_cephfs.py
@@ -205,7 +205,6 @@ class CephFSManifests(SafeManifest):
     def config(self) -> Dict:
         """Returns current config available from charm config and joined relations."""
         config: Dict = {}
-        config["image-registry"] = "rocks.canonical.com:443/cdk"
 
         config.update(**self.charm.ceph_context)
         config.update(**self.charm.kubernetes_context)

--- a/src/manifests_config.py
+++ b/src/manifests_config.py
@@ -121,7 +121,7 @@ class CephCsiConfig(Addition):
 
 
 class ConfigManifests(SafeManifest):
-    """Deployment Specific details for the aws-ebs-csi-driver."""
+    """Manage Ceph CSI configuration manifests."""
 
     def __init__(self, charm: "CephCsiCharm"):
         self.namespace = cast(str, charm.stored.namespace)

--- a/src/manifests_rbd.py
+++ b/src/manifests_rbd.py
@@ -106,7 +106,7 @@ class ProvisionerAdjustments(Patch):
     """Update RBD provisioner."""
 
     def __call__(self, obj: AnyResource) -> None:
-        """Use the image-registry config and updates container images in obj."""
+        """Mutates CSI RBD Provisioner Deployment replicas/hostNetwork and DaemonSet kubelet_dir paths."""
         if (
             obj.kind == "Deployment"
             and obj.metadata
@@ -177,7 +177,6 @@ class RBDManifests(SafeManifest):
     def config(self) -> Dict:
         """Returns current config available from charm config and joined relations."""
         config: Dict = {}
-        config["image-registry"] = "rocks.canonical.com:443/cdk"
 
         config.update(**self.charm.ceph_context)
         config.update(**self.charm.kubernetes_context)


### PR DESCRIPTION
This is a backport of 6edfaadff9 to the 1.31 release, which is still under support. This is needed to prevent juju from overwriting the image-registry parameter in airgapped environments which do not use the rocks.canonical.com