### PR TITLE
PRs and Nightly tests bootstrap on vsphere using updated org variables

### DIFF
--- a/.github/workflows/vsphere-integration.yaml
+++ b/.github/workflows/vsphere-integration.yaml
@@ -53,12 +53,17 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: vsphere
-          credentials-yaml: ${{ secrets.CREDENTIALS_YAML }}
+          juju-channel: "3/stable"
           charmcraft-channel: ${{ steps.charmcraft.outputs.channel }}
+          credentials-yaml: ${{ secrets.CREDENTIALS_YAML }}
           clouds-yaml: ${{ secrets.CLOUDS_YAML }}
           bootstrap-constraints: "arch=amd64 cores=2 mem=4G"
-          bootstrap-options: "${{ secrets.JAMMY_BOOTSTRAP_OPTIONS }} --model-default datastore=vsanDatastore --model-default primary-network=VLAN_2763 --config caas-image-repo=rocks.canonical.com/cdk/jujusolutions"
-          juju-channel: "3/stable"
+          bootstrap-options: >-
+            ${{ vars.VSPHERE_BOOTSTRAP_NOBLE }}
+            ${{ vars.VSPHERE_BOOTSTRAP_DATASTORE }}
+            ${{ vars.VSPHERE_BOOTSTRAP_VLAN_2763 }}
+            ${{ vars.VSPHERE_BOOTSTRAP_HARDWARE_VERSION }}
+            --config caas-image-repo=rocks.canonical.com/cdk/jujusolutions
 
       - if: ${{ needs.charm-source.outputs.channel }}
         name: Test from ceph-csi channel=${{ needs.charm-source.outputs.channel }}


### PR DESCRIPTION
This pull request updates the `vsphere-integration.yaml` GitHub Actions workflow to improve how bootstrap options are managed and to clarify configuration. The main change is the refactoring of the `bootstrap-options` parameter to use reusable variables, which enhances maintainability and flexibility.

Workflow configuration improvements:

* Refactored the `bootstrap-options` in the `charmed-kubernetes/actions-operator` step to use multiple workflow variables (`VSPHERE_BOOTSTRAP_NOBLE`, `VSPHERE_BOOTSTRAP_DATASTORE`, `VSPHERE_BOOTSTRAP_VLAN_2763`, `VSPHERE_BOOTSTRAP_HARDWARE_VERSION`) instead of a single secret and hardcoded values, making the configuration more modular and easier to update.
* Moved the `juju-channel` input above the `credentials-yaml` input for improved clarity and consistency in the workflow step definition.
* No functional changes to the credentials or cloud configuration inputs; only their order was adjusted for readability.