### PR TITLE
feature: add configurable reclaim-policy for storage classes

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -371,6 +371,24 @@ config:
         The current release deployed is available by viewing
           juju status ceph-csi
 
+    default-reclaim-policy:
+      default: "Delete"
+      description: |
+        The reclaim policy for all storage classes created by this charm.
+
+        Valid values are "Delete" and "Retain".
+
+        "Delete" means that when a PersistentVolumeClaim is deleted, the underlying
+        Ceph volume is also automatically deleted.
+
+        "Retain" means that the Ceph volume is kept even after the
+        PersistentVolumeClaim is deleted. This allows for manual recovery of
+        data from the volume after deletion of the claim.
+
+        NOTE: Kubernetes does not allow changing the reclaimPolicy of an existing
+        StorageClass. This option only takes effect before the StorageClass is created.
+      type: string
+
 actions:
   list-versions:
     description: List versions supported by this charm

--- a/src/literals.py
+++ b/src/literals.py
@@ -23,3 +23,7 @@ DEFAULT_SC_ANNOTATION = {DEFAULT_SC_ANNOTATION_NAME: "true"}
 
 CONFIG_CEPH_RBD_ENABLE = "ceph-rbd-enable"
 CONFIG_CEPHFS_ENABLE = "cephfs-enable"
+
+CONFIG_RECLAIM_POLICY = "default-reclaim-policy"
+CONFIG_RECLAIM_POLICY_DEFAULT = "Delete"
+VALID_RECLAIM_POLICIES = ["Delete", "Retain"]

--- a/src/manifests_cephfs.py
+++ b/src/manifests_cephfs.py
@@ -96,12 +96,16 @@ class CephStorageClass(StorageClassFactory):
 
         self.update_params(parameters)
 
+        reclaim_policy = self.manifests.config.get(
+            literals.CONFIG_RECLAIM_POLICY, literals.CONFIG_RECLAIM_POLICY_DEFAULT
+        )
+
         return StorageClass.from_dict(
             dict(
                 metadata=metadata,
                 provisioner=driver_name,
                 allowVolumeExpansion=True,
-                reclaimPolicy="Delete",
+                reclaimPolicy=reclaim_policy,
                 parameters=parameters,
             )
         )
@@ -256,6 +260,15 @@ class CephFSManifests(SafeManifest):
         if not self.config.get("enabled"):
             log.info("Skipping CephFS evaluation since it's disabled")
             return None
+
+        reclaim_policy = self.config.get(
+            literals.CONFIG_RECLAIM_POLICY, literals.CONFIG_RECLAIM_POLICY_DEFAULT
+        )
+        if reclaim_policy not in literals.VALID_RECLAIM_POLICIES:
+            return (
+                f"Invalid default-reclaim-policy '{reclaim_policy}', "
+                f"valid options are {literals.VALID_RECLAIM_POLICIES}"
+            )
 
         props = CephFSSecret.REQUIRED_CONFIG.keys() | RbacAdjustments.REQUIRED_CONFIG
         for prop in sorted(props):

--- a/src/manifests_rbd.py
+++ b/src/manifests_rbd.py
@@ -86,13 +86,17 @@ class CephStorageClass(StorageClassFactory):
 
         self.update_params(parameters)
 
+        reclaim_policy = self.manifests.config.get(
+            literals.CONFIG_RECLAIM_POLICY, literals.CONFIG_RECLAIM_POLICY_DEFAULT
+        )
+
         return StorageClass.from_dict(
             dict(
                 metadata=metadata,
                 provisioner=driver_name,
                 allowVolumeExpansion=True,
                 mountOptions=["discard"],
-                reclaimPolicy="Delete",
+                reclaimPolicy=reclaim_policy,
                 parameters=parameters,
             )
         )
@@ -166,6 +170,15 @@ class RBDManifests(SafeManifest):
         if not self.config.get("enabled"):
             log.info("Skipping CephRBD evaluation since it's disabled")
             return None
+
+        reclaim_policy = self.config.get(
+            literals.CONFIG_RECLAIM_POLICY, literals.CONFIG_RECLAIM_POLICY_DEFAULT
+        )
+        if reclaim_policy not in literals.VALID_RECLAIM_POLICIES:
+            return (
+                f"Invalid default-reclaim-policy '{reclaim_policy}', "
+                f"valid options are {literals.VALID_RECLAIM_POLICIES}"
+            )
 
         props = (
             CephRBDSecret.REQUIRED_CONFIG.keys()

--- a/tests/unit/test_manifests_cephfs.py
+++ b/tests/unit/test_manifests_cephfs.py
@@ -159,6 +159,17 @@ def test_ceph_storage_class_modelled(caplog):
     assert csc() == [expected]
     assert f"Modelling storage class sc='{TEST_CEPH_FS_ALT.name}'" in caplog.text
 
+    # check default reclaim policy is Delete
+    assert csc()[0].reclaimPolicy == "Delete"
+
+    manifest.config["default-reclaim-policy"] = "Retain"
+    expected.reclaimPolicy = "Retain"
+    assert csc() == [expected]
+
+    manifest.config["default-reclaim-policy"] = "Delete"
+    expected.reclaimPolicy = "Delete"
+    assert csc() == [expected]
+
 
 def test_ceph_storage_class_purging(caplog):
     caplog.set_level(logging.INFO)
@@ -218,6 +229,19 @@ def test_manifest_evaluation(caplog):
     )
 
     charm.config[sc_name_formatter_key] = "cephfs-{name}"
+    assert manifests.evaluate() is None
+
+    # check invalid reclaim policy is caught
+    charm.config["default-reclaim-policy"] = "Invalid"
+    assert (
+        manifests.evaluate()
+        == "Invalid default-reclaim-policy 'Invalid', valid options are ['Delete', 'Retain']"
+    )
+
+    charm.config["default-reclaim-policy"] = "Retain"
+    assert manifests.evaluate() is None
+
+    charm.config["default-reclaim-policy"] = "Delete"
     assert manifests.evaluate() is None
 
     charm.config["cephfs-tolerations"] = "key=value,Foo"

--- a/tests/unit/test_manifests_rbd.py
+++ b/tests/unit/test_manifests_rbd.py
@@ -116,6 +116,17 @@ def test_ceph_storage_class_modelled(caplog, fs_type):
     assert csc() == expected
     assert f"Modelling storage class {sc_name}" in caplog.text
 
+    # check default reclaim policy is Delete
+    assert csc().reclaimPolicy == "Delete"
+
+    manifest.config["default-reclaim-policy"] = "Retain"
+    expected.reclaimPolicy = "Retain"
+    assert csc() == expected
+
+    manifest.config["default-reclaim-policy"] = "Delete"
+    expected.reclaimPolicy = "Delete"
+    assert csc() == expected
+
 
 @pytest.mark.parametrize("fs_type", ["xfs", "ext4"])
 def test_ceph_storage_class_purging(caplog, fs_type):
@@ -164,6 +175,18 @@ def test_manifest_evaluation(caplog):
     assert manifests.evaluate() == err_formatter.format("ceph-ext4-storage-class-name-formatter")
 
     charm.config["ceph-ext4-storage-class-name-formatter"] = "ceph-ext4"
+    assert manifests.evaluate() is None
+
+    charm.config["default-reclaim-policy"] = "Invalid"
+    assert (
+        manifests.evaluate()
+        == "Invalid default-reclaim-policy 'Invalid', valid options are ['Delete', 'Retain']"
+    )
+
+    charm.config["default-reclaim-policy"] = "Retain"
+    assert manifests.evaluate() is None
+
+    charm.config["default-reclaim-policy"] = "Delete"
     assert manifests.evaluate() is None
 
     charm.config["ceph-rbd-tolerations"] = "key=value,Foo"


### PR DESCRIPTION
Add a 'reclaim-policy' charm config option (valid values: 'Delete', 'Retain'; default: 'Delete') so that operators can set the StorageClass reclaim-policy at deploy time. Both manifests_rbd and manifests_cephfs read this value from config rather than using the hard-coded value 'Delete'.

For backward compatibility, the `reclaim-policy` defaults to 'Delete', which matches the original hard-coded value.

Closes: #44