### PR TITLE
fix: wrap StoredState attributes with str() to fix mypy unreachable error

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -97,9 +97,9 @@ class UpdateStatusHandler(ops.Object):
         elif unready := self.charm.collector.unready:
             status.add(ops.WaitingStatus(", ".join(unready)))
             raise status.ReconcilerError("Waiting for deployment")
-        elif self.charm.stored.namespace != self.charm._configured_ns:
+        elif str(self.charm.stored.namespace) != self.charm._configured_ns:
             status.add(ops.BlockedStatus("Namespace cannot be changed after deployment"))
-        elif self.charm.stored.drivername != self.charm._configured_drivername:
+        elif str(self.charm.stored.drivername) != self.charm._configured_drivername:
             status.add(
                 ops.BlockedStatus("csidriver-name-formatter cannot be changed after deployment")
             )


### PR DESCRIPTION
mypy's type narrowing incorrectly resolves BoundStoredState's overloaded `__getattr__` as a callable type rather than `Any`, causing it to conclude that != str comparisons are always True and marking subsequent elif branches as unreachable.

This change wraps `self.charm.stored.namespace` and `self.charm.stored.namespace` in `str()` to prevent mypy from inferring that these elif branches are unreachable.